### PR TITLE
Don't remove map if not allowed to damage item frames there

### DIFF
--- a/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
@@ -31,6 +31,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -239,9 +240,10 @@ public class MapItemManager implements Listener
         
     }
     
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH)
     static public void onEntityDamage(EntityDamageByEntityEvent event)
     {
+        if(event.isCancelled()) return;
         if(!(event.getEntity() instanceof ItemFrame)) return;
         if(!(event.getDamager() instanceof Player)) return;
         


### PR DESCRIPTION
If the EntityDamageByEntityEvent is cancelled (for example by a plugin like WorldGuard) the maps should not be removed. The event handler is on high priority, to allow other plugins to cancel the event first.