### PR TITLE
Stores whole image in the images folder and adds moderation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Main command to manage the maps. The less used in everyday usage, too.
 
 
 
-##Configuration
+## Configuration
 
 ```yaml
 # Plugin language. Empty: system language.

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -35,12 +35,12 @@ import fr.zcraft.zlib.tools.PluginLogger;
 import java.io.File;
 import java.io.IOException;
 
+
 public final class ImageOnMap extends ZPlugin
 {
     static private final String IMAGES_DIRECTORY_NAME = "images";
     static private final String MAPS_DIRECTORY_NAME = "maps";
     static private ImageOnMap plugin;
-    
     private File imagesDirectory;
     private final File mapsDirectory;
 
@@ -63,6 +63,11 @@ public final class ImageOnMap extends ZPlugin
         return new File(imagesDirectory, "map"+mapID+".png");
     }
     
+    public File getFullImageFile(short mapIDstart, short mapIDend)
+    {
+        return new File(imagesDirectory, "_"+mapIDstart+"-"+mapIDend+".png");
+    }
+    
     @SuppressWarnings ("unchecked")
     @Override
     public void onEnable()
@@ -79,14 +84,17 @@ public final class ImageOnMap extends ZPlugin
             this.setEnabled(false);
             return;
         }
-
+        
+        
         saveDefaultConfig();
 
         loadComponents(I18n.class, Gui.class, Commands.class, PluginConfiguration.class, ImageIOExecutor.class, ImageRendererExecutor.class);
         
+        PluginConfiguration.initialize();
+       
         //Init all the things !
         MetricsLite.startMetrics();
-        I18n.setPrimaryLocale(PluginConfiguration.LANG.get());
+        I18n.setPrimaryLocale(PluginConfiguration.LANG);
 
         MapManager.init();
         MapInitEvent.init();

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -18,13 +18,7 @@
 
 package fr.moribus.imageonmap;
 
-import fr.moribus.imageonmap.commands.maptool.DeleteCommand;
-import fr.moribus.imageonmap.commands.maptool.ExploreCommand;
-import fr.moribus.imageonmap.commands.maptool.GetCommand;
-import fr.moribus.imageonmap.commands.maptool.GetRemainingCommand;
-import fr.moribus.imageonmap.commands.maptool.ListCommand;
-import fr.moribus.imageonmap.commands.maptool.MigrateCommand;
-import fr.moribus.imageonmap.commands.maptool.NewCommand;
+import fr.moribus.imageonmap.commands.maptool.*;
 import fr.moribus.imageonmap.image.ImageIOExecutor;
 import fr.moribus.imageonmap.image.ImageRendererExecutor;
 import fr.moribus.imageonmap.image.MapInitEvent;
@@ -103,6 +97,9 @@ public final class ImageOnMap extends ZPlugin
                 NewCommand.class,
                 ListCommand.class,
                 GetCommand.class,
+                GetOtherCommand.class,
+                ListOtherCommand.class,
+                DeleteOtherCommand.class,
                 DeleteCommand.class,
                 GetRemainingCommand.class,
                 ExploreCommand.class,

--- a/src/main/java/fr/moribus/imageonmap/MetricsLite.java
+++ b/src/main/java/fr/moribus/imageonmap/MetricsLite.java
@@ -57,7 +57,7 @@ public class MetricsLite
      */
     static public void startMetrics()
     {
-        if(!PluginConfiguration.COLLECT_DATA.get()) return;
+        if(!PluginConfiguration.COLLECT_DATA) return;
 
         try
         {

--- a/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
+++ b/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
@@ -21,6 +21,7 @@ package fr.moribus.imageonmap;
 import fr.zcraft.zlib.components.configuration.Configuration;
 import fr.zcraft.zlib.components.configuration.ConfigurationItem;
 
+import java.io.*;
 import java.util.Locale;
 
 import static fr.zcraft.zlib.components.configuration.ConfigurationItem.item;
@@ -28,10 +29,93 @@ import static fr.zcraft.zlib.components.configuration.ConfigurationItem.item;
 
 public final class PluginConfiguration extends Configuration
 {
-    static public ConfigurationItem<Locale> LANG = item("lang", Locale.class);
+	static public Locale LANG = Locale.ENGLISH;
 
-    static public ConfigurationItem<Boolean> COLLECT_DATA = item("collect-data", true);
+	static public Boolean COLLECT_DATA = false;
 
-    static public ConfigurationItem<Integer> MAP_GLOBAL_LIMIT = item("map-global-limit", 0, "Limit-map-by-server");
-    static public ConfigurationItem<Integer> MAP_PLAYER_LIMIT = item("map-player-limit", 0, "Limit-map-by-player");
+	static public Integer MAP_GLOBAL_LIMIT = 0;
+	static public Integer MAP_PLAYER_LIMIT = 0;
+
+	static public Integer LIMIT_SIZE_X = 0;
+	static public Integer LIMIT_SIZE_Y= 0;
+	static public Boolean SAVE_FULL_IMAGE = false;
+	FileInputStream in = null;
+
+	public static void initialize() {
+
+		try {
+			FileInputStream fis = new FileInputStream(new File(ImageOnMap.getPlugin().getDataFolder(), "config.yml"));
+			 
+			BufferedReader br = new BufferedReader(new InputStreamReader(fis));
+			String line = null;
+			line = br.readLine();//2
+			line = br.readLine();//3
+			line = br.readLine();//4
+			line = br.readLine();//5
+			line = br.readLine(); //We're now at line 6.
+			line = br.readLine(); //lang is in Line.
+			
+			if(line.contains("en_US")) LANG = Locale.ENGLISH;
+			if(line.contains("fr_FR")) LANG = Locale.FRENCH;
+			else LANG = Locale.ENGLISH;
+
+			line = br.readLine();//8
+			line = br.readLine();//9
+			line = br.readLine();//10
+			line = br.readLine();//11
+			line = br.readLine();//Collect-data in line.
+			
+			if(line.contains("true")) COLLECT_DATA = true;
+			
+			line = br.readLine();//13
+			line = br.readLine();//14
+			line = br.readLine();//15
+			line = br.readLine();//16
+			line = br.readLine();//17
+			line = br.readLine();//map-global-limit
+			
+			line = line.substring(17, line.length() - 1);
+			try{MAP_GLOBAL_LIMIT = Integer.parseInt(line);}
+			catch(NumberFormatException e) {MAP_GLOBAL_LIMIT = 0;}
+			
+			//It's even the same line length! Nothing new needs to be done.
+			line = br.readLine();//map-player-limit
+			//map-player-limit: 172
+			//012345678901234567890
+			line = line.substring(17, line.length() - 1);
+			try{MAP_PLAYER_LIMIT = Integer.parseInt(line);}
+			catch(NumberFormatException e) {MAP_PLAYER_LIMIT = 0;}
+
+			line = br.readLine();//20
+			line = br.readLine();//21
+			line = br.readLine();//22
+
+			line = br.readLine();//limit-map-size-x
+			//Lucky break! same code. Again!
+			line = line.substring(17, line.length() - 1);
+			try{LIMIT_SIZE_X = Integer.parseInt(line);}
+			catch(NumberFormatException e) {LIMIT_SIZE_X = 0;}
+			
+			line = br.readLine();//limit-map-size-x
+			//Lucky break! same code. Again!
+			line = line.substring(17, line.length() - 1);
+			try{LIMIT_SIZE_Y = Integer.parseInt(line);}
+			catch(NumberFormatException e) {LIMIT_SIZE_Y = 0;}
+			
+			line = br.readLine();//25
+			line = br.readLine();//26
+			line = br.readLine();//27
+			
+			line = br.readLine();//line holds save-full-image.
+			if(line.contains("true")) {
+				SAVE_FULL_IMAGE = true;
+			}
+			br.close();
+			fis.close();
+		}
+		catch(IOException e){
+
+		}
+	}
+	
 }

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/DeleteOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/DeleteOtherCommand.java
@@ -26,11 +26,9 @@ import fr.zcraft.zlib.components.commands.CommandException;
 import fr.zcraft.zlib.components.commands.CommandInfo;
 import fr.zcraft.zlib.components.commands.WithFlags;
 import fr.zcraft.zlib.components.i18n.I;
-import fr.zcraft.zlib.components.rawtext.RawText;
 import fr.zcraft.zlib.tools.PluginLogger;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/DeleteOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/DeleteOtherCommand.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2013 Moribus
+ * Copyright (C) 2015 ProkopyL <prokopylmc@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.moribus.imageonmap.commands.maptool;
+
+import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.MapManager;
+import fr.moribus.imageonmap.map.MapManagerException;
+import fr.zcraft.zlib.components.commands.CommandException;
+import fr.zcraft.zlib.components.commands.CommandInfo;
+import fr.zcraft.zlib.components.commands.WithFlags;
+import fr.zcraft.zlib.components.i18n.I;
+import fr.zcraft.zlib.components.rawtext.RawText;
+import fr.zcraft.zlib.tools.PluginLogger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.UUID;
+
+@CommandInfo (name =  "deleteother", usageParameters = "<player name> <map name>")
+@WithFlags ({"confirm"})
+public class DeleteOtherCommand extends IoMCommand
+{
+    @Override
+    protected void run() throws CommandException
+    {
+    	if(!playerSender().hasPermission("imageonmap.delete.other")) {
+    		warning(I.t("You do not have permission for this command. (imageonmap.delete.other)"));
+    		return;
+    	}
+
+		Player player = null;
+		UUID uuid = null;
+		OfflinePlayer op = null;
+        player = Bukkit.getPlayer(args[0]);
+        if(player == null){
+        	op = Bukkit.getOfflinePlayer(args[0]);
+			if(op.hasPlayedBefore()) uuid = op.getUniqueId();
+			else warning(I.t("We've never seen that player before!"));
+        }
+        else uuid = player.getUniqueId();
+        String mapName = "";
+        mapName = args[1];
+		if(args.length > 2) for(int i = 2; i < args.length; i++) mapName += (" " + args[i - 1]);
+		
+		ImageMap map = MapManager.getMap(uuid, mapName);
+        
+        if(player != null) MapManager.clear(player.getInventory(), map);
+        //if(player == null) MapManager.clear(op.getPlayer().getInventory(), map);
+        
+            try
+            {
+                MapManager.deleteMap(map);
+                info(I.t("Map successfully deleted."));
+            }
+            catch (MapManagerException ex)
+            {
+                PluginLogger.warning("A non-existent map was requested to be deleted", ex);
+                warning(I.t("This map does not exist."));
+            }
+        }
+   
+    
+    @Override
+    protected List<String> complete() throws CommandException
+    {
+        if(args.length == 1) 
+            return getMatchingMapNames(playerSender(), args[0]);
+
+        return null;
+    }
+}

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GetOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GetOtherCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2013 Moribus
+ * Copyright (C) 2015 ProkopyL <prokopylmc@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.moribus.imageonmap.commands.maptool;
+
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.gui.MapListGui;
+import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.MapManager;
+import fr.moribus.imageonmap.map.MapManagerException;
+import fr.zcraft.zlib.components.commands.CommandException;
+import fr.zcraft.zlib.components.commands.CommandInfo;
+import fr.zcraft.zlib.components.gui.Gui;
+import fr.zcraft.zlib.components.i18n.I;
+
+
+@CommandInfo (name = "getother", usageParameters = "<PlayerName> <MapName>")
+public class GetOtherCommand extends IoMCommand
+{
+	@SuppressWarnings("deprecation")
+	@Override
+	protected void run() throws CommandException
+	{
+		//Deny those who do not have permission.
+		if(!playerSender().hasPermission("imageonmap.get.other")) {
+    		warning(I.t("You do not have permission for this command. (imageonmap.get.other)"));
+    		return;
+    	}
+		
+		Player player = null;
+		UUID uuid = null;
+        player = Bukkit.getPlayer(args[0]);
+        if(player == null){
+        	OfflinePlayer op = Bukkit.getOfflinePlayer(args[0]);
+			if(op.hasPlayedBefore()) uuid = op.getUniqueId();
+			else warning(I.t("We've never seen that player before!"));
+        }
+        else {
+        	uuid = player.getUniqueId();        	
+        }
+		ImageMap map = null;
+		String mapName = "";
+		mapName = args[1];
+		if(args.length > 2) {
+			for(int i = 2; i < args.length; i++) {
+				mapName += (" " + args[i - 1]);
+			}
+		}
+		map = MapManager.getMap(uuid, mapName);
+		map.give(playerSender());
+		return;
+	}
+}

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GetOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GetOtherCommand.java
@@ -26,13 +26,10 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import fr.moribus.imageonmap.commands.IoMCommand;
-import fr.moribus.imageonmap.gui.MapListGui;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
-import fr.moribus.imageonmap.map.MapManagerException;
 import fr.zcraft.zlib.components.commands.CommandException;
 import fr.zcraft.zlib.components.commands.CommandInfo;
-import fr.zcraft.zlib.components.gui.Gui;
 import fr.zcraft.zlib.components.i18n.I;
 
 

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/ListOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/ListOtherCommand.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2013 Moribus
+ * Copyright (C) 2015 ProkopyL <prokopylmc@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fr.moribus.imageonmap.commands.maptool;
+
+
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.MapManager;
+import fr.moribus.imageonmap.map.PosterMap;
+import fr.zcraft.zlib.components.commands.CommandException;
+import fr.zcraft.zlib.components.commands.CommandInfo;
+import fr.zcraft.zlib.components.i18n.I;
+import fr.zcraft.zlib.components.rawtext.RawText;
+import fr.zcraft.zlib.components.rawtext.RawTextPart;
+import fr.zcraft.zlib.tools.items.ItemStackBuilder;
+import fr.zcraft.zlib.tools.text.RawMessage;
+
+
+@CommandInfo (name = "listother", usageParameters = "<PlayerName>")
+public class ListOtherCommand extends IoMCommand
+{
+	@Override
+    protected void run() throws CommandException
+    {
+		if(!playerSender().hasPermission("imageonmap.list.other")) {
+    		warning(I.t("You do not have permission for this command. (imageonmap.list.other)"));
+    		return;
+    	}
+		
+		Player player = null;
+		UUID uuid = null;
+        player = Bukkit.getPlayer(args[0]);
+        if(player == null){
+        	OfflinePlayer op = Bukkit.getOfflinePlayer(args[0]);
+			if(op.hasPlayedBefore()) {
+				uuid = op.getUniqueId();
+			}
+			else {
+				warning(I.t("We've never seen that player before!"));
+				
+			}
+        }
+        else{
+        	 uuid = player.getUniqueId();
+        }
+       
+        List<ImageMap> mapList = null;
+        try{
+        	mapList = MapManager.getMapList(uuid);
+        }
+        catch(Exception e){
+        	
+        }
+        if(mapList.isEmpty())
+        {
+            info(I.t("No map found."));
+            return;
+        }
+        
+        info(I.tn("{white}{bold}{0} map found.", "{white}{bold}{0} maps found.", mapList.size()));
+
+        RawTextPart rawText = new RawText("");
+        rawText = addMap(rawText, mapList.get(0));
+
+        for(int i = 1, c = mapList.size(); i < c; i++)
+        {
+            rawText = rawText.then(", ").color(ChatColor.GRAY);
+            rawText = addMap(rawText, mapList.get(i));
+        }
+
+        RawMessage.send(playerSender(), rawText.build());
+    }
+
+    private RawTextPart<?> addMap(RawTextPart<?> rawText, ImageMap map)
+    {
+        final String size = map.getType() == ImageMap.Type.SINGLE ? "1 × 1" : ((PosterMap) map).getColumnCount() + " × " + ((PosterMap) map).getRowCount();
+
+        return rawText
+                .then(map.getId())
+                .color(ChatColor.WHITE)
+                .command(GetCommand.class, map.getId())
+                .hover(new ItemStackBuilder(Material.MAP)
+                                .title(ChatColor.GREEN + "" + ChatColor.BOLD + map.getName())
+                                .lore(ChatColor.GRAY + map.getId() + ", " + size)
+                                .lore("")
+                                .lore(I.t("{white}Click{gray} to get this map"))
+                                .hideAttributes()
+                                .item()
+                );
+    }
+}

--- a/src/main/java/fr/moribus/imageonmap/gui/MapListGui.java
+++ b/src/main/java/fr/moribus/imageonmap/gui/MapListGui.java
@@ -125,8 +125,8 @@ public class MapListGui extends ExplorerGui<ImageMap>
         int imagesCount = MapManager.getMapList(getPlayer().getUniqueId()).size();
         int mapPartCount = MapManager.getMapPartCount(getPlayer().getUniqueId());
 
-        int mapGlobalLimit = PluginConfiguration.MAP_GLOBAL_LIMIT.get();
-        int mapPersonalLimit = PluginConfiguration.MAP_PLAYER_LIMIT.get();
+        int mapGlobalLimit = PluginConfiguration.MAP_GLOBAL_LIMIT;
+        int mapPersonalLimit = PluginConfiguration.MAP_PLAYER_LIMIT;
 
         int mapPartGloballyLeft = mapGlobalLimit - MapManager.getMapCount();
         int mapPartPersonallyLeft = mapPersonalLimit - mapPartCount;

--- a/src/main/java/fr/moribus/imageonmap/map/MapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/map/MapManager.java
@@ -18,12 +18,13 @@
 
 package fr.moribus.imageonmap.map;
 
-import fr.moribus.imageonmap.ImageOnMap;
 import fr.moribus.imageonmap.PluginConfiguration;
 import fr.moribus.imageonmap.image.ImageIOExecutor;
 import fr.moribus.imageonmap.image.PosterImage;
 import fr.moribus.imageonmap.map.MapManagerException.Reason;
 import fr.zcraft.zlib.tools.PluginLogger;
+import fr.moribus.imageonmap.ImageOnMap;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
@@ -281,7 +282,7 @@ abstract public class MapManager
     
     static public void checkMapLimit(int newMapsCount, UUID userUUID) throws MapManagerException
     {
-        int limit = PluginConfiguration.MAP_GLOBAL_LIMIT.get();
+        int limit = PluginConfiguration.MAP_GLOBAL_LIMIT;
 
         if (limit > 0 && getMapCount() + newMapsCount > limit)
             throw new MapManagerException(Reason.MAXIMUM_SERVER_MAPS_EXCEEDED);

--- a/src/main/java/fr/moribus/imageonmap/map/PlayerMapStore.java
+++ b/src/main/java/fr/moribus/imageonmap/map/PlayerMapStore.java
@@ -18,10 +18,11 @@
 
 package fr.moribus.imageonmap.map;
 
-import fr.moribus.imageonmap.ImageOnMap;
 import fr.moribus.imageonmap.PluginConfiguration;
 import fr.moribus.imageonmap.map.MapManagerException.Reason;
 import fr.zcraft.zlib.tools.PluginLogger;
+import fr.moribus.imageonmap.ImageOnMap;
+
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -154,7 +155,7 @@ public class PlayerMapStore implements ConfigurationSerializable
     
     public void checkMapLimit(int newMapsCount) throws MapManagerException
     {
-        int limit = PluginConfiguration.MAP_PLAYER_LIMIT.get();
+        int limit = PluginConfiguration.MAP_PLAYER_LIMIT;
         if(limit <= 0) return;
         
         if(getMapCount() + newMapsCount > limit)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,7 +8,7 @@ lang:
 
 # Allows collection of anonymous statistics on plugin environment and usage
 # The statistics are publicly visible here: http://mcstats.org/plugin/ImageOnMap
-collect-data: true
+collect-data: false
 
 
 # Images rendered on maps consume Minecraft maps ID, and there are only 32 767 of them.
@@ -16,3 +16,12 @@ collect-data: true
 # 0 means unlimited.
 map-global-limit: 0
 map-player-limit: 0
+
+
+#Maximum size in pixels for an image to be. 0 is unlimited.
+limit-map-size-x: 0
+limit-map-size-y: 0
+
+
+#Should the full image be saved when a map is rendered?
+save-full-image: false;

--- a/src/main/resources/help/maptool.txt
+++ b/src/main/resources/help/maptool.txt
@@ -3,6 +3,7 @@ new: Creates a new ImageOnMap
 delete: Deletes a map.
 delete-noconfirm: Deletes a map. Deletion is permanent and made without confirmation
 get: Gives you a map.
+getother: Opens another's MapTool GUI
 getremaining: Gives you the remaining maps that could not fit in your inventory
 list: Lists all the map you currently have.
 explore: Opens a GUI to see and manage your maps.

--- a/src/main/resources/help/maptool/getother.txt
+++ b/src/main/resources/help/maptool/getother.txt
@@ -1,0 +1,8 @@
+Opens a GUI to list and manage others' maps.
+
+From there, you can:
+- list all the maps you rendered on this server;
+- get copies of maps you rendered;
+- get parts of posters in case of need;
+- delete or rename your maps (organization!);
+- see their statistics (maps rendered, left...).

--- a/src/main/resources/help/maptool/listother.txt
+++ b/src/main/resources/help/maptool/listother.txt
@@ -1,0 +1,1 @@
+Lists another player's maps.


### PR DESCRIPTION
This pull req adds a few commands and removes a few unnecessary imports. Nothing too major; The new commands have permissions imageonmap.command.other, and simply allows administrative action. It's possible that merging could close Issue #30. 

Update:
Config.yml is read now, and has lots of variables.
PluginConfiguration can init, which may or may not be necessary.
Full image saving works, so Issue #36 can close. The format for naming is "_\<start MAPID\>-\<end MAPID\>.png"

Closes #30 
Closes #36