### PR TITLE
Remove reverted permission from imageonmap.*

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,7 +23,6 @@ permissions:
             imageonmap.explore: true
             imageonmap.rename: true
             imageonmap.delete: true
-            imageonmap.administrative: false
 
     imageonmap.userender:
         description: "Allows you to use /tomap and related commands (/maptool getremaing). Alias of imageonmap.new."


### PR DESCRIPTION
It currently causes the player to have the permission imageonmap.administrative when you give him ^imageonmap.* (to remove the default permissions), because it is inverted.. This is surely not intended.