### PR TITLE
Allow map creation from console, for other players [1.16.3]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
                 <configuration>
                     <artifactSet>
                         <includes>
-                            <include>fr.zcraft:zlib</include>
+                            <include>com.github.zDevelopers:zLib</include>
                             <include>org.bstats:bstats-bukkit</include>
                         </includes>
                     </artifactSet>
                     <relocations>
                         <relocation>
-                            <pattern>fr.zcraft.zlib</pattern>
+                            <pattern>com.github.zDevelopers</pattern>
                             <shadedPattern>fr.moribus.imageonmap</shadedPattern>
                         </relocation>
                         <relocation>
@@ -54,11 +54,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
-        <repository>
-            <id>zDevelopers</id>
-            <url>http://maven.carrade.eu/artifactory/snapshots</url>
-        </repository>
-
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
         <!-- bStats -->
         <repository>
             <id>CodeMC</id>
@@ -73,10 +72,9 @@
             <version>1.13.2-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>fr.zcraft</groupId>
-            <artifactId>zlib</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>compile</scope>
+            <groupId>com.github.zDevelopers</groupId>
+            <artifactId>zLib</artifactId>
+            <version>1.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -125,6 +125,7 @@ public final class ImageOnMap extends ZPlugin
 
         Commands.registerShortcut("maptool", NewCommand.class, "tomap");
         Commands.registerShortcut("maptool", ExploreCommand.class, "maps");
+        Commands.registerShortcut("maptool", GiveCommand.class, "mapgive");
 
         if (PluginConfiguration.CHECK_FOR_UPDATES.get())
         {

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -117,10 +117,10 @@ public final class ImageOnMap extends ZPlugin
                 ListCommand.class,
                 GetCommand.class,
                 DeleteCommand.class,
+                GiveCommand.class,
                 GetRemainingCommand.class,
                 ExploreCommand.class,
-                MigrateCommand.class,
-                GiveCommand.class
+                MigrateCommand.class
         );
 
         Commands.registerShortcut("maptool", NewCommand.class, "tomap");

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -119,7 +119,8 @@ public final class ImageOnMap extends ZPlugin
                 DeleteCommand.class,
                 GetRemainingCommand.class,
                 ExploreCommand.class,
-                MigrateCommand.class
+                MigrateCommand.class,
+                GiveCommand.class
         );
 
         Commands.registerShortcut("maptool", NewCommand.class, "tomap");

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -116,6 +116,7 @@ public final class ImageOnMap extends ZPlugin
         Commands.register(
                 "maptool",
                 NewCommand.class,
+                NewOtherCommand.class,
                 ListCommand.class,
                 ListOtherCommand.class,
                 GetCommand.class,

--- a/src/main/java/fr/moribus/imageonmap/Permissions.java
+++ b/src/main/java/fr/moribus/imageonmap/Permissions.java
@@ -42,6 +42,7 @@ import org.bukkit.permissions.Permissible;
 public enum Permissions
 {
     NEW("imageonmap.new", "imageonmap.userender"),
+    NEWOTHER("imageonmap.newother", "imageonmap.userender"),
     LIST("imageonmap.list"),
     LISTOTHER("imageonmap.listother"),
     GET("imageonmap.get"),

--- a/src/main/java/fr/moribus/imageonmap/Permissions.java
+++ b/src/main/java/fr/moribus/imageonmap/Permissions.java
@@ -46,7 +46,8 @@ public enum Permissions
     RENAME("imageonmap.rename"),
     DELETE("imageonmap.delete"),
     ADMINISTRATIVE("imageonmap.administrative"),
-    BYPASS_SIZE("imageonmap.bypasssize")
+    BYPASS_SIZE("imageonmap.bypasssize"),
+    GIVE("imageonmap.give")
 
     ;
 

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -77,10 +77,6 @@ public class GiveCommand extends IoMCommand
                     return;
                 }
             }
-            if (p == null) {
-                player.sendMessage(I.t("Player not found"));
-                return;
-            }
             map = MapManager.getMap(player.getUniqueId(), args[1]);
             if (map == null) {
                 player.sendMessage(I.t("Map not found"));

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -67,15 +67,6 @@ public class GiveCommand extends IoMCommand
             }
             if (args.length == 3) {
                 player = getPlayerParameter(2);
-                if(player==null){
-                    try{
-                        playerSender().sendMessage(I.t("Player map store not found"));
-                    }
-                    catch (Exception e){
-
-                    }
-                    return;
-                }
             }
             map = MapManager.getMap(player.getUniqueId(), args[1]);
             if (map == null) {

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -79,8 +79,7 @@ public class GiveCommand extends IoMCommand
             }
             map = MapManager.getMap(player.getUniqueId(), args[1]);
             if (map == null) {
-                player.sendMessage(I.t("Map not found"));
-                return;
+                throwInvalidArgument(I.t("Map not found"));
             }
             map.give(p);
         }

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -56,7 +56,7 @@ public class GiveCommand extends IoMCommand
     {
         if(args.length < 2) throwInvalidArgument(I.t("You must give a valid player name and a map name."));
 
-        final Player p= Bukkit.getPlayer(args[0]);
+        final Player p = getPlayerParameter(0);
 
         ImageMap map;
         //TODO does not support map name with space

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -66,7 +66,7 @@ public class GiveCommand extends IoMCommand
                 player = playerSender();
             }
             if (args.length == 3) {
-                player = Bukkit.getPlayer(args[2]);
+                player = getPlayerParameter(2);
                 if(player==null){
                     try{
                         playerSender().sendMessage(I.t("Player map store not found"));

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright or © or Copr. Moribus (2013)
+ * Copyright or © or Copr. ProkopyL <prokopylmc@gmail.com> (2015)
+ * Copyright or © or Copr. Amaury Carrade <amaury@carrade.eu> (2016 – 2020)
+ * Copyright or © or Copr. Vlammar <valentin.jabre@gmail.com> (2019 – 2020)
+ *
+ * This software is a computer program whose purpose is to allow insertion of
+ * custom images in a Minecraft world.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.moribus.imageonmap.commands.maptool;
+
+import fr.moribus.imageonmap.Permissions;
+import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.MapManager;
+import fr.zcraft.zlib.components.commands.CommandException;
+import fr.zcraft.zlib.components.commands.CommandInfo;
+import fr.zcraft.zlib.components.i18n.I;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+
+@CommandInfo (name = "give", usageParameters = "<Player> <MapName> or <Player> <MapName> <Player where to find the map>")
+public class GiveCommand extends IoMCommand
+{
+    @Override
+    protected void run() throws CommandException
+    {
+        if(args.length < 2) throwInvalidArgument(I.t("You must give a valid player name and a map name."));
+
+        final Player p= Bukkit.getPlayer(args[0]);
+
+        ImageMap map;
+        //TODO does not support map name with space
+        Player player=null;
+        if(args.length<4) {
+            if (args.length == 2) {
+                player = playerSender();
+            }
+            if (args.length == 3) {
+                player = Bukkit.getPlayer(args[2]);
+                if(player==null){
+                    try{
+                        playerSender().sendMessage(I.t("Player map store not found"));
+                    }
+                    catch (Exception e){
+
+                    }
+                    return;
+                }
+            }
+            if (p == null) {
+                player.sendMessage(I.t("Player not found"));
+                return;
+            }
+            map = MapManager.getMap(player.getUniqueId(), args[1]);
+            if (map == null) {
+                player.sendMessage(I.t("Map not found"));
+                return;
+            }
+            map.give(p);
+        }
+    }
+
+    @Override
+    public boolean canExecute(CommandSender sender)
+    {
+        return Permissions.GIVE.grantedTo(sender);
+    }
+}

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewOtherCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewOtherCommand.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright or © or Copr. Moribus (2013)
+ * Copyright or © or Copr. ProkopyL <prokopylmc@gmail.com> (2015)
+ * Copyright or © or Copr. Amaury Carrade <amaury@carrade.eu> (2016 – 2020)
+ * Copyright or © or Copr. Vlammar <valentin.jabre@gmail.com> (2019 – 2020)
+ *
+ * This software is a computer program whose purpose is to allow insertion of
+ * custom images in a Minecraft world.
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.moribus.imageonmap.commands.maptool;
+
+import fr.moribus.imageonmap.Permissions;
+import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.image.ImageRendererExecutor;
+import fr.moribus.imageonmap.image.ImageUtils;
+import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.PosterMap;
+import fr.zcraft.zlib.components.commands.CommandException;
+import fr.zcraft.zlib.components.commands.CommandInfo;
+import fr.zcraft.zlib.components.i18n.I;
+import fr.zcraft.zlib.components.worker.WorkerCallback;
+import fr.zcraft.zlib.tools.PluginLogger;
+import fr.zcraft.zlib.tools.text.ActionBar;
+import fr.zcraft.zlib.tools.text.MessageSender;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@CommandInfo (name = "newother", usageParameters = "<Playername> <URL> [resize]")
+public class NewOtherCommand  extends IoMCommand
+{
+    @Override
+    protected void run() throws CommandException
+    {
+        ImageUtils.ScalingType scaling = ImageUtils.ScalingType.NONE;
+        URL url;
+        int width = 0, height = 0;
+        Player foundPlayer = null;
+        if(args.length < 1) throwInvalidArgument(I.t("You must give an PlayerName to give the image to."));
+        if(args.length < 2) throwInvalidArgument(I.t("You must give an URL to take the image from."));
+
+        try {
+            foundPlayer = getOfflinePlayerParameter(0).getPlayer();
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        if(foundPlayer == null) throwInvalidArgument(I.t("That player is not online!."));
+        
+        final Player player = foundPlayer;
+        
+        try
+        {
+            url = new URL(args[1]);
+        }
+        catch(MalformedURLException ex)
+        {
+            throwInvalidArgument(I.t("Invalid URL."));
+            return;
+        }
+        
+        if(args.length >= 3)
+        {
+            if(args.length >= 4) {
+                width = Integer.parseInt(args[3]);
+                height = Integer.parseInt(args[4]);
+            }
+
+            switch(args[2]) {
+                case "resize": scaling = ImageUtils.ScalingType.CONTAINED; break;
+                case "resize-stretched": scaling = ImageUtils.ScalingType.STRETCHED; break;
+                case "resize-covered": scaling = ImageUtils.ScalingType.COVERED; break;
+                default: throwInvalidArgument(I.t("Invalid Stretching mode.")); break;
+            }
+        }
+        try {
+
+
+            ActionBar.sendPermanentMessage(player, ChatColor.DARK_GREEN + I.t("Rendering..."));
+            ImageRendererExecutor.render(url, scaling, player.getUniqueId(), width, height, new WorkerCallback<ImageMap>() {
+                @Override
+                public void finished(ImageMap result) {
+                    ActionBar.removeMessage(player);
+                    MessageSender.sendActionBarMessage(player, ChatColor.DARK_GREEN + I.t("Rendering finished!"));
+
+                    if (result.give(player) && (result instanceof PosterMap && !((PosterMap) result).hasColumnData())) {
+                        info(I.t("The rendered map was too big to fit in your inventory."));
+                        info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                    }
+                }
+
+                @Override
+                public void errored(Throwable exception) {
+                    player.sendMessage(I.t("{ce}Map rendering failed: {0}", exception.getMessage()));
+
+                    PluginLogger.warning("Rendering from {0} failed: {1}: {2}",
+                            player.getName(),
+                            exception.getClass().getCanonicalName(),
+                            exception.getMessage());
+                }
+            });
+        }
+        //Added to fix bug with rendering displaying after error
+        finally {
+            ActionBar.removeMessage(player);
+        }
+    }
+
+    @Override
+    public boolean canExecute(CommandSender sender)
+    {
+        return Permissions.NEWOTHER.grantedTo(sender);
+    }
+}

--- a/src/main/java/fr/moribus/imageonmap/image/ImageIOExecutor.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageIOExecutor.java
@@ -61,6 +61,7 @@ public class ImageIOExecutor extends Worker
             {
                 BufferedImage image = ImageIO.read(file);
                 mapRenderer.setImage(image);
+                image.flush();//Safe to free
                 return null;
             }
         });
@@ -88,7 +89,9 @@ public class ImageIOExecutor extends Worker
     {
         for(int i = 0, c = mapsIDs.length; i < c; i++)
         {
-            ImageIOExecutor.saveImage(ImageOnMap.getPlugin().getImageFile(mapsIDs[i]), image.getImageAt(i));
+            BufferedImage img=image.getImageAt(i);
+            ImageIOExecutor.saveImage(ImageOnMap.getPlugin().getImageFile(mapsIDs[i]), img);
+            img.flush();//Safe to free
         }
     }
     

--- a/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
@@ -92,7 +92,7 @@ public class ImageRendererExecutor extends Worker
 
                 BufferedImage image=null;
                 //If the link is an imgur one
-                if (url.toString().startsWith("https://imgur.com/")) {
+                if (url.toString().toLowerCase().startsWith("https://imgur.com/")) {
 
                     //Not handled, can't with the hash only access the image in i.imgur.com/<hash>.<extension>
 

--- a/src/main/java/fr/moribus/imageonmap/image/ImageUtils.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageUtils.java
@@ -36,9 +36,12 @@
 
 package fr.moribus.imageonmap.image;
 
+import fr.zcraft.zlib.tools.PluginLogger;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
+//import java.awt.*;
 /**
  * Various image-related utilities
  */
@@ -57,6 +60,7 @@ public class ImageUtils {
                 case COVERED: return ImageUtils.resize(source, destinationW, destinationH, true);
                 case STRETCHED: return resizeStretched(source, destinationW, destinationH);
                 default: return source;
+
             }
         }
     }
@@ -70,28 +74,31 @@ public class ImageUtils {
      */
     static private BufferedImage resize(BufferedImage source, int destinationW, int destinationH, boolean covered)
     {
-        float ratioW = (float)destinationW / (float)source.getWidth();
-        float ratioH = (float)destinationH / (float)source.getHeight();
-        int finalW, finalH;
-        int x, y;
+        try {
+            float ratioW = (float) destinationW / (float) source.getWidth();
+            float ratioH = (float) destinationH / (float) source.getHeight();
+            int finalW, finalH;
+            int x, y;
 
-        if(covered ? ratioW > ratioH : ratioW < ratioH)
-        {
-            finalW = destinationW;
-            finalH = (int)(source.getHeight() * ratioW);
+            if (covered ? ratioW > ratioH : ratioW < ratioH) {
+                finalW = destinationW;
+                finalH = (int) (source.getHeight() * ratioW);
+            } else {
+                finalW = (int) (source.getWidth() * ratioH);
+                finalH = destinationH;
+            }
+
+            x = (destinationW - finalW) / 2;
+            y = (destinationH - finalH) / 2;
+
+            return drawImage(source,
+                    destinationW, destinationH,
+                    x, y, finalW, finalH);
         }
-        else
-        {
-            finalW = (int)(source.getWidth() * ratioH);
-            finalH = destinationH;
+        catch(final Throwable e){
+            throw e;
         }
 
-        x = (destinationW - finalW) / 2;
-        y = (destinationH - finalH) / 2;
-
-        return drawImage(source,
-                destinationW, destinationH,
-                x, y, finalW, finalH);
     }
 
     /**
@@ -123,11 +130,22 @@ public class ImageUtils {
                                           int bufferW, int bufferH,
                                           int posX, int posY,
                                           int sourceW, int sourceH) {
-        BufferedImage newImage = new BufferedImage(bufferW, bufferH, BufferedImage.TYPE_INT_ARGB);
+        Graphics graphics=null;
+        BufferedImage newImage= null;
+       try{
+         newImage = new BufferedImage(bufferW, bufferH, BufferedImage.TYPE_INT_ARGB);
 
-        Graphics graphics = newImage.getGraphics();
+        graphics = newImage.getGraphics();
         graphics.drawImage(source, posX, posY, sourceW, sourceH, null);
-        graphics.dispose();
+
         return newImage;
+       }
+       catch(final Throwable e) {
+           PluginLogger.warning("Exception/error at drawImage");
+           if(newImage!=null )
+               newImage.flush();//Safe to free
+           throw e;
+       }
+
     }
 }

--- a/src/main/java/fr/moribus/imageonmap/image/ImageUtils.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageUtils.java
@@ -41,68 +41,42 @@ import fr.zcraft.zlib.tools.PluginLogger;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
-//import java.awt.*;
 /**
  * Various image-related utilities
  */
 public class ImageUtils {
 
-    public enum ScalingType {
-        NONE,
-        CONTAINED,
-        COVERED,
-        STRETCHED,
-        ;
-
-        public BufferedImage resize(BufferedImage source, int destinationW, int destinationH) {
-            switch(this) {
-                case CONTAINED: return ImageUtils.resize(source, destinationW, destinationH, false);
-                case COVERED: return ImageUtils.resize(source, destinationW, destinationH, true);
-                case STRETCHED: return resizeStretched(source, destinationW, destinationH);
-                default: return source;
-
-            }
-        }
-    }
-
     /**
      * Generates a resized buffer of the given source
+     *
      * @param source
      * @param destinationW
      * @param destinationH
      * @return
      */
-    static private BufferedImage resize(BufferedImage source, int destinationW, int destinationH, boolean covered)
-    {
-        try {
-            float ratioW = (float) destinationW / (float) source.getWidth();
-            float ratioH = (float) destinationH / (float) source.getHeight();
-            int finalW, finalH;
-            int x, y;
+    static private BufferedImage resize(BufferedImage source, int destinationW, int destinationH, boolean covered) {
+        float ratioW = (float) destinationW / (float) source.getWidth();
+        float ratioH = (float) destinationH / (float) source.getHeight();
+        int finalW, finalH;
+        int x, y;
 
-            if (covered ? ratioW > ratioH : ratioW < ratioH) {
-                finalW = destinationW;
-                finalH = (int) (source.getHeight() * ratioW);
-            } else {
-                finalW = (int) (source.getWidth() * ratioH);
-                finalH = destinationH;
-            }
-
-            x = (destinationW - finalW) / 2;
-            y = (destinationH - finalH) / 2;
-
-            return drawImage(source,
-                    destinationW, destinationH,
-                    x, y, finalW, finalH);
-        }
-        catch(final Throwable e){
-            throw e;
+        if (covered ? ratioW > ratioH : ratioW < ratioH) {
+            finalW = destinationW;
+            finalH = (int) (source.getHeight() * ratioW);
+        } else {
+            finalW = (int) (source.getWidth() * ratioH);
+            finalH = destinationH;
         }
 
+        x = (destinationW - finalW) / 2;
+        y = (destinationH - finalH) / 2;
+
+        return drawImage(source,
+                destinationW, destinationH,
+                x, y, finalW, finalH);
     }
 
     /**
-     *
      * @param source
      * @param destinationW
      * @param destinationH
@@ -117,35 +91,57 @@ public class ImageUtils {
     /**
      * Draws the source image on a new buffer, and returns it.
      * The source buffer can be drawn at any size and position in the new buffer.
-     * @param source The source buffer to draw
+     *
+     * @param source  The source buffer to draw
      * @param bufferW The width of the new buffer
      * @param bufferH The height of the new buffer
-     * @param posX The X position of the source buffer
-     * @param posY The Y position of the source buffer
+     * @param posX    The X position of the source buffer
+     * @param posY    The Y position of the source buffer
      * @param sourceW The width of the source buffer
      * @param sourceH The height of the source buffer
      * @return The new buffer, with the source buffer drawn on it
      */
     static private BufferedImage drawImage(BufferedImage source,
-                                          int bufferW, int bufferH,
-                                          int posX, int posY,
-                                          int sourceW, int sourceH) {
-        Graphics graphics=null;
-        BufferedImage newImage= null;
-       try{
-         newImage = new BufferedImage(bufferW, bufferH, BufferedImage.TYPE_INT_ARGB);
+                                           int bufferW, int bufferH,
+                                           int posX, int posY,
+                                           int sourceW, int sourceH) {
+        Graphics graphics = null;
+        BufferedImage newImage = null;
+        try {
+            newImage = new BufferedImage(bufferW, bufferH, BufferedImage.TYPE_INT_ARGB);
 
-        graphics = newImage.getGraphics();
-        graphics.drawImage(source, posX, posY, sourceW, sourceH, null);
+            graphics = newImage.getGraphics();
+            graphics.drawImage(source, posX, posY, sourceW, sourceH, null);
 
-        return newImage;
-       }
-       catch(final Throwable e) {
-           PluginLogger.warning("Exception/error at drawImage");
-           if(newImage!=null )
-               newImage.flush();//Safe to free
-           throw e;
-       }
+            return newImage;
+        } catch (final Throwable e) {
+            PluginLogger.warning("Exception/error at drawImage");
+            if (newImage != null)
+                newImage.flush();//Safe to free
+            throw e;
+        }
 
+    }
+
+    public enum ScalingType {
+        NONE,
+        CONTAINED,
+        COVERED,
+        STRETCHED,
+        ;
+
+        public BufferedImage resize(BufferedImage source, int destinationW, int destinationH) {
+            switch (this) {
+                case CONTAINED:
+                    return ImageUtils.resize(source, destinationW, destinationH, false);
+                case COVERED:
+                    return ImageUtils.resize(source, destinationW, destinationH, true);
+                case STRETCHED:
+                    return resizeStretched(source, destinationW, destinationH);
+                default:
+                    return source;
+
+            }
+        }
     }
 }

--- a/src/main/java/fr/moribus/imageonmap/image/PosterImage.java
+++ b/src/main/java/fr/moribus/imageonmap/image/PosterImage.java
@@ -36,88 +36,84 @@
 
 package fr.moribus.imageonmap.image;
 
-import java.awt.*;
+
+import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 
 /**
  * This class represents an image split into pieces
  */
-public class PosterImage
-{
+public class PosterImage {
     static private final int WIDTH = 128;
     static private final int HEIGHT = 128;
-    
+
     private BufferedImage originalImage;
     private BufferedImage[] cutImages;
     private int lines;
     private int columns;
     private int cutImagesCount;
     private int remainderX, remainderY;
-    
+
     /**
      * Creates a new Poster from an entire image
+     *
      * @param originalImage the original image
      */
-    public PosterImage(BufferedImage originalImage)
-    {
+    public PosterImage(BufferedImage originalImage) {
         this.originalImage = originalImage;
         calculateDimensions();
     }
-    
-    private void calculateDimensions()
-    {
+
+    private void calculateDimensions() {
         int originalWidth = originalImage.getWidth();
         int originalHeight = originalImage.getHeight();
-        
+
         columns = (int) Math.ceil(originalWidth / WIDTH);
         lines = (int) Math.ceil(originalHeight / HEIGHT);
-        
+
         remainderX = originalWidth % WIDTH;
         remainderY = originalHeight % HEIGHT;
-        
-        if(remainderX > 0) columns++;
-        if(remainderY > 0) lines++;
-        
+
+        if (remainderX > 0) columns++;
+        if (remainderY > 0) lines++;
+
         cutImagesCount = columns * lines;
     }
-    
-    public void splitImages()
-    {
-        try{
-        cutImages = new BufferedImage[cutImagesCount];
-        
-        int imageX;
-        int imageY = remainderY == 0 ? 0 :(remainderY - HEIGHT) / 2;
-        for(int i = 0; i < lines; i++)
-        {
-            imageX = remainderX == 0 ? 0 :(remainderX - WIDTH) / 2;
-            for(int j = 0; j < columns; j++)
-            {
-                cutImages[i * columns + j] = makeSubImage(originalImage, imageX, imageY);
-                imageX += WIDTH;
+
+    public void splitImages() {
+        try {
+            cutImages = new BufferedImage[cutImagesCount];
+
+            int imageX;
+            int imageY = remainderY == 0 ? 0 : (remainderY - HEIGHT) / 2;
+            for (int i = 0; i < lines; i++) {
+                imageX = remainderX == 0 ? 0 : (remainderX - WIDTH) / 2;
+                for (int j = 0; j < columns; j++) {
+                    cutImages[i * columns + j] = makeSubImage(originalImage, imageX, imageY);
+                    imageX += WIDTH;
+                }
+                imageY += HEIGHT;
             }
-            imageY += HEIGHT;
-        }
-        }
-        catch(final Throwable e){
-            if(cutImages!=null)
-                for(BufferedImage bi: cutImages){
-                    if(bi!=null){
+        } catch (final Throwable e) {
+            if (cutImages != null)
+                for (BufferedImage bi : cutImages) {
+                    if (bi != null) {
                         bi.flush();//Safe to free
                     }
                 }
-            throw e;}
+            throw e;
+        }
 
     }
-    
+
     /**
      * Generates the subimage that intersects with the given map rectangle.
+     *
      * @param x X coordinate of top-left point of the map.
      * @param y Y coordinate of top-left point of the map.
      * @return the requested subimage.
      */
-    private BufferedImage makeSubImage(BufferedImage originalImage, int x, int y)
-    {
+    private BufferedImage makeSubImage(BufferedImage originalImage, int x, int y) {
 
         BufferedImage newImage = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
 
@@ -126,79 +122,64 @@ public class PosterImage
         graphics.drawImage(originalImage, -x, -y, null);
         return newImage;
     }
-    
+
     /**
-     * 
      * @return the split images
      */
-    public BufferedImage[] getImages()
-    {
+    public BufferedImage[] getImages() {
         return cutImages;
     }
-    
-    public BufferedImage getImageAt(int i)
-    {
+
+    public BufferedImage getImageAt(int i) {
         return cutImages[i];
     }
-    public BufferedImage getImage()
-    {
+
+    public BufferedImage getImage() {
         return originalImage;
     }
-    
-    public int getColumnAt(int i)
-    {
+
+    public int getColumnAt(int i) {
         return i % columns;
     }
-    
-    public int getLineAt(int i)
-    {
+
+    public int getLineAt(int i) {
         return i / columns;
     }
-    
+
     /**
-     * 
      * @return the number of lines of the poster
      */
-    public int getLines()
-    {
+    public int getLines() {
         return lines;
     }
-    
+
     /**
-     * 
      * @return the number of columns of the poster
      */
-    public int getColumns()
-    {
+    public int getColumns() {
         return columns;
     }
-    
+
     /**
-     * 
      * @return the number of split images
      */
-    public int getImagesCount()
-    {
+    public int getImagesCount() {
         return cutImagesCount;
     }
 
-    public int getRemainderX()
-    {
+    public int getRemainderX() {
         return remainderX;
     }
 
-    public void setRemainderX(int remainderX)
-    {
+    public void setRemainderX(int remainderX) {
         this.remainderX = remainderX;
     }
 
-    public int getRemainderY()
-    {
+    public int getRemainderY() {
         return remainderY;
     }
 
-    public void setRemainderY(int remainderY)
-    {
+    public void setRemainderY(int remainderY) {
         this.remainderY = remainderY;
     }
 }

--- a/src/main/java/fr/moribus/imageonmap/image/PosterImage.java
+++ b/src/main/java/fr/moribus/imageonmap/image/PosterImage.java
@@ -36,7 +36,7 @@
 
 package fr.moribus.imageonmap.image;
 
-import java.awt.Graphics;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 
 /**
@@ -83,6 +83,7 @@ public class PosterImage
     
     public void splitImages()
     {
+        try{
         cutImages = new BufferedImage[cutImagesCount];
         
         int imageX;
@@ -97,8 +98,16 @@ public class PosterImage
             }
             imageY += HEIGHT;
         }
-        
-        originalImage = null;
+        }
+        catch(final Throwable e){
+            if(cutImages!=null)
+                for(BufferedImage bi: cutImages){
+                    if(bi!=null){
+                        bi.flush();//Safe to free
+                    }
+                }
+            throw e;}
+
     }
     
     /**
@@ -109,12 +118,12 @@ public class PosterImage
      */
     private BufferedImage makeSubImage(BufferedImage originalImage, int x, int y)
     {
+
         BufferedImage newImage = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
-        
+
         Graphics graphics = newImage.getGraphics();
-        
+
         graphics.drawImage(originalImage, -x, -y, null);
-        graphics.dispose();
         return newImage;
     }
     
@@ -130,6 +139,10 @@ public class PosterImage
     public BufferedImage getImageAt(int i)
     {
         return cutImages[i];
+    }
+    public BufferedImage getImage()
+    {
+        return originalImage;
     }
     
     public int getColumnAt(int i)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ commands:
       description: Manage maps
    maps:
       description: Manage maps through a GUI
+   mapgive:
+     description: give a map to a player from a player map store, by default take from the player that make the command
+     usage: /<command> player_to map_name [player_from]
 
 permissions:
     imageonmap.*:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -25,6 +25,7 @@ permissions:
             imageonmap.rename: true
             imageonmap.delete: true
             imageonmap.bypasssize: false
+            imageonmap.give: false
 
     imageonmap.userender:
         description: "Allows you to use /tomap and related commands (/maptool getremaing). Alias of imageonmap.new."
@@ -53,6 +54,10 @@ permissions:
     imageonmap.delete:
         description: "Allows you to delete a map you rendered in the past."
         default: true
+
+    imageonmap.give:
+      description: "Allows you to give a map to a specified player."
+      default: op
 
     imageonmap.administrative:
         description: "Allows you to perform administrative tasks (like /maptool migrate)."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,6 +43,10 @@ permissions:
         description: "Allows you to use /tomap and related commands (/maptool getremaining)."
         default: true
 
+    imageonmap.newother:
+        description: "Allows you to create maps for other players."
+        default: true
+
     imageonmap.list:
       description: "Allows you to list the images you rendered."
       default: true


### PR DESCRIPTION
- Merges in the changes from #119 and resolves conflicts.
- Fixes broken dependencies from Maven,
- Adds a command to allow for map generation to be done without needing a sender player, this allows you to render maps through the console / rcon, to give to players.

`/maptool newother <PlayerName> <URL> [resize] [w] [h]`

