### PR TITLE
1.17 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 9, 10, 11, 12, 13, 14, 15]
+        java: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        java: [8, 11, 16, 17]
 
     steps:
       - name: Checkout

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.moribus</groupId>
     <artifactId>ImageOnMap</artifactId>
-    <version>4.1.2</version>
+    <version>4.2.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -43,7 +43,6 @@ import fr.moribus.imageonmap.commands.maptool.GetCommand;
 import fr.moribus.imageonmap.commands.maptool.GetRemainingCommand;
 import fr.moribus.imageonmap.commands.maptool.GiveCommand;
 import fr.moribus.imageonmap.commands.maptool.ListCommand;
-import fr.moribus.imageonmap.commands.maptool.MigrateCommand;
 import fr.moribus.imageonmap.commands.maptool.NewCommand;
 import fr.moribus.imageonmap.commands.maptool.RenameCommand;
 import fr.moribus.imageonmap.commands.maptool.UpdateCommand;
@@ -51,8 +50,6 @@ import fr.moribus.imageonmap.image.ImageIOExecutor;
 import fr.moribus.imageonmap.image.ImageRendererExecutor;
 import fr.moribus.imageonmap.image.MapInitEvent;
 import fr.moribus.imageonmap.map.MapManager;
-import fr.moribus.imageonmap.migration.MigratorExecutor;
-import fr.moribus.imageonmap.migration.V3Migrator;
 import fr.moribus.imageonmap.ui.MapItemManager;
 import fr.zcraft.quartzlib.components.commands.CommandWorkers;
 import fr.zcraft.quartzlib.components.commands.Commands;
@@ -104,7 +101,7 @@ public final class ImageOnMap extends QuartzPlugin {
     public void onEnable() {
         // Creating the images and maps directories if necessary
         try {
-            imagesDirectory = checkPluginDirectory(imagesDirectory, V3Migrator.getOldImagesDirectory(this));
+            //imagesDirectory = checkPluginDirectory(imagesDirectory, V3Migrator.getOldImagesDirectory(this));
             checkPluginDirectory(mapsDirectory);
         } catch (final IOException ex) {
             PluginLogger.error("FATAL: " + ex.getMessage());
@@ -136,7 +133,7 @@ public final class ImageOnMap extends QuartzPlugin {
                 GiveCommand.class,
                 GetRemainingCommand.class,
                 ExploreCommand.class,
-                MigrateCommand.class,
+                //MigrateCommand.class,//Removed for now doesn't work nor is useful, maybe useful later on
                 UpdateCommand.class
         );
 
@@ -161,7 +158,7 @@ public final class ImageOnMap extends QuartzPlugin {
     public void onDisable() {
         MapManager.exit();
         MapItemManager.exit();
-        MigratorExecutor.waitForMigration();
+        //MigratorExecutor.waitForMigration();//Removed for now doesn't work nor is useful, maybe useful later on
 
         super.onDisable();
     }

--- a/src/main/java/fr/moribus/imageonmap/Permissions.java
+++ b/src/main/java/fr/moribus/imageonmap/Permissions.java
@@ -51,6 +51,7 @@ public enum Permissions {
     GETOTHER("imageonmap.getother"),
     RENAME("imageonmap.rename"),
     PLACE_SPLATTER_MAP("imageonmap.placesplattermap"),
+    PLACE_INVISIBLE_SPLATTER_MAP("imageonmap.placeinvisiblesplattermap"),
     REMOVE_SPLATTER_MAP("imageonmap.removesplattermap"),
     DELETE("imageonmap.delete"),
     DELETEOTHER("imageonmap.deleteother"),

--- a/src/main/java/fr/moribus/imageonmap/Permissions.java
+++ b/src/main/java/fr/moribus/imageonmap/Permissions.java
@@ -60,7 +60,8 @@ public enum Permissions {
     BYPASS_SIZE("imageonmap.bypasssize"),
     BYPASS_IMAGE_LIMIT("imageonmap.bypassimagelimit"),
     BYPASS_MAP_LIMIT("imageonmap.bypassmaplimit"),
-    GIVE("imageonmap.give");
+    GIVE("imageonmap.give"),
+    IGNOREALLOWLIST("imageonmap.ignoreallowlist_hostingsite");
 
     private final String permission;
     private final String[] aliases;

--- a/src/main/java/fr/moribus/imageonmap/Permissions.java
+++ b/src/main/java/fr/moribus/imageonmap/Permissions.java
@@ -37,7 +37,11 @@
 package fr.moribus.imageonmap;
 
 
+import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.tools.PluginLogger;
+import java.util.Set;
 import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 
 public enum Permissions {
     NEW("imageonmap.new", "imageonmap.userender"),
@@ -54,6 +58,8 @@ public enum Permissions {
     UPDATEOTHER("imageonmap.updateother"),
     ADMINISTRATIVE("imageonmap.administrative"),
     BYPASS_SIZE("imageonmap.bypasssize"),
+    BYPASS_IMAGE_LIMIT("imageonmap.bypassimagelimit"),
+    BYPASS_MAP_LIMIT("imageonmap.bypassmaplimit"),
     GIVE("imageonmap.give");
 
     private final String permission;
@@ -82,5 +88,38 @@ public enum Permissions {
         }
 
         return false;
+    }
+
+    /**
+     * Return the limit of map the user is allowed to make
+     *
+     * @param permissible The permissible to check.
+     * @return the limit
+     */
+    public int getLimitPermission(Permissible permissible, LimitType type) {
+        Set<PermissionAttachmentInfo> perms = permissible.getEffectivePermissions();
+        String prefix = String.format("imageonmap.%slimit.", type.name());
+        for (PermissionAttachmentInfo pai : perms) {
+            String permString = pai.getPermission().toLowerCase();
+            if (permString.startsWith(prefix)) {
+                if (pai.getValue()) {
+                    try {
+                        int limit = Integer.parseInt(permString.split(prefix)[1].trim());
+                        return limit;
+                    } catch (Exception e) {
+                        PluginLogger.warning(
+                                I.t("The correct syntax for setting map limit node is: ImageOnMap.mapLimit.X "
+                                        + "where you can replace X with the limit of map a player is allowed to have"));
+                    }
+
+                }
+            }
+        }
+        return 2147483647; //Virtually no limit
+    }
+
+    public enum LimitType {
+        map,
+        image
     }
 }

--- a/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
+++ b/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
@@ -59,4 +59,6 @@ public final class PluginConfiguration extends Configuration {
     public static ConfigurationItem<Integer> LIMIT_SIZE_X = item("limit-map-size-x", 0);
     public static ConfigurationItem<Integer> LIMIT_SIZE_Y = item("limit-map-size-y", 0);
 
+    public static ConfigurationItem<String> ALLOWLIST_HOSTINGSITE = item("allowlist_hostingsite", "");
+
 }

--- a/src/main/java/fr/moribus/imageonmap/commands/IoMCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/IoMCommand.java
@@ -57,15 +57,12 @@ public abstract class IoMCommand extends Command {
 
 
     protected boolean checkHostingSite(URL url) {
-        PluginLogger.info("allow list " + PluginConfiguration.ALLOWLIST_HOSTINGSITE.get());
         String urlsString = PluginConfiguration.ALLOWLIST_HOSTINGSITE.get();
-        if (urlsString.trim().equals("")) {
+        if (urlsString.trim().isEmpty()) {
             return true;
         }
         String[] hosts = urlsString.trim().replaceAll("https://","").split(",");
         for (String host : hosts) {
-            PluginLogger.info(host);
-            PluginLogger.info(url.getHost());
             if (url.getHost().equals(host.trim())) {
                 return true;
             }

--- a/src/main/java/fr/moribus/imageonmap/commands/IoMCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/IoMCommand.java
@@ -36,11 +36,14 @@
 
 package fr.moribus.imageonmap.commands;
 
+import fr.moribus.imageonmap.PluginConfiguration;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.components.commands.Command;
 import fr.zcraft.quartzlib.components.commands.CommandException;
 import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.tools.PluginLogger;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -52,6 +55,23 @@ import org.bukkit.entity.Player;
 
 public abstract class IoMCommand extends Command {
 
+
+    protected boolean checkHostingSite(URL url) {
+        PluginLogger.info("allow list " + PluginConfiguration.ALLOWLIST_HOSTINGSITE.get());
+        String urlsString = PluginConfiguration.ALLOWLIST_HOSTINGSITE.get();
+        if (urlsString.trim().equals("")) {
+            return true;
+        }
+        String[] hosts = urlsString.trim().replaceAll("https://","").split(",");
+        for (String host : hosts) {
+            PluginLogger.info(host);
+            PluginLogger.info(url.getHost());
+            if (url.getHost().equals(host.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     protected void retrieveUUID(String arg, Consumer<UUID> consumer) {
         UUID uuid;

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
@@ -121,7 +121,7 @@ public class NewCommand extends IoMCommand {
             }
             scaling = resizeMode();
         }
-        if (width == 0 || height == 0) {
+        if (width < 0 || height < 0) {
             throwInvalidArgument(I.t("You need to specify a valid size. e.g. resize 4 5"));
             return;
         }

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
@@ -41,6 +41,7 @@ import fr.moribus.imageonmap.commands.IoMCommand;
 import fr.moribus.imageonmap.image.ImageRendererExecutor;
 import fr.moribus.imageonmap.image.ImageUtils;
 import fr.moribus.imageonmap.map.ImageMap;
+import fr.moribus.imageonmap.map.MapManager;
 import fr.moribus.imageonmap.map.PosterMap;
 import fr.zcraft.quartzlib.components.commands.CommandException;
 import fr.zcraft.quartzlib.components.commands.CommandInfo;
@@ -87,7 +88,23 @@ public class NewCommand extends IoMCommand {
         if (args.length < 1) {
             throwInvalidArgument(I.t("You must give an URL to take the image from."));
         }
-
+        //Checking if the map limit and image limit
+        if (!Permissions.BYPASS_IMAGE_LIMIT.grantedTo(player)) {
+            int imageLimit = Permissions.NEW.getLimitPermission(player, Permissions.LimitType.image);
+            int imageCount = MapManager.getPlayerMapStore(player.getUniqueId()).getImagesCount();
+            if (imageLimit <= imageCount) {
+                throwInvalidArgument(
+                        I.t("Your image limit is set to {0} and you currently have {1} ", imageLimit, imageCount));
+            }
+        }
+        if (!Permissions.BYPASS_MAP_LIMIT.grantedTo(player)) {
+            int mapLimit = Permissions.NEW.getLimitPermission(player, Permissions.LimitType.map);
+            int mapCount = MapManager.getPlayerMapStore(player.getUniqueId()).getMapCount();
+            if (mapLimit <= mapCount) {
+                throwInvalidArgument(
+                        I.t("Your map limit is set to {0} and you currently have {1} ", mapLimit, mapCount));
+            }
+        }
         try {
             url = new URL(args[0]);
         } catch (MalformedURLException ex) {

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
@@ -107,6 +107,12 @@ public class NewCommand extends IoMCommand {
         }
         try {
             url = new URL(args[0]);
+            if (!Permissions.IGNOREALLOWLIST.grantedTo(player) && !checkHostingSite(url)) {
+                throwInvalidArgument(I.t("This hosting website is not trusted, if you think that this is an error "
+                        + " contact your server administrator"));
+                return;
+            }
+
         } catch (MalformedURLException ex) {
             throwInvalidArgument(I.t("Invalid URL."));
             return;

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
@@ -94,7 +94,9 @@ public class NewCommand extends IoMCommand {
             int imageCount = MapManager.getPlayerMapStore(player.getUniqueId()).getImagesCount();
             if (imageLimit <= imageCount) {
                 throwInvalidArgument(
-                        I.t("Your image limit is set to {0} and you currently have {1} ", imageLimit, imageCount));
+                        I.t("Your image limit is set to {0} and you currently have {1} loaded image(s)",
+                                imageLimit,
+                                imageCount));
             }
         }
         if (!Permissions.BYPASS_MAP_LIMIT.grantedTo(player)) {
@@ -102,7 +104,9 @@ public class NewCommand extends IoMCommand {
             int mapCount = MapManager.getPlayerMapStore(player.getUniqueId()).getMapCount();
             if (mapLimit <= mapCount) {
                 throwInvalidArgument(
-                        I.t("Your map limit is set to {0} and you currently have {1} ", mapLimit, mapCount));
+                        I.t("Your map limit is set to {0} and you currently have {1} loaded map(s)",
+                                mapLimit,
+                                mapCount));
             }
         }
         try {

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/UpdateCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/UpdateCommand.java
@@ -168,6 +168,12 @@ public class UpdateCommand extends IoMCommand {
             URL url1;
             try {
                 url1 = new URL(url);
+                if (!Permissions.IGNOREALLOWLIST.grantedTo(playerSender) && !checkHostingSite(url1)) {
+                    throwInvalidArgument(I.t("This hosting website is not trusted, if you think that this is an error "
+                            + " contact your server administrator"));
+                    return;
+                }
+
                 //TODO replace by a check of the load status.(if not loaded load the mapmanager)
                 MapManager.load(false);//we don't want to spam the console each time we reload the mapManager
 
@@ -211,7 +217,7 @@ public class UpdateCommand extends IoMCommand {
                         ActionBar.removeMessage(playerSender);
                     }
                 }
-            } catch (MalformedURLException ex) {
+            } catch (MalformedURLException | CommandException ex) {
                 warning(sender, I.t("Invalid URL."));
             }
         });

--- a/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
+++ b/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
@@ -236,7 +236,7 @@ public class MapDetailGui extends ExplorerGui<Integer> {
             }, map.getName(), this);
 
         } catch (IllegalStateException e) {
-            PluginLogger.info("error while renaming");
+            PluginLogger.error("Error while renaming map: ", e);
         }
     }
 

--- a/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
+++ b/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
@@ -46,6 +46,7 @@ import fr.zcraft.quartzlib.components.gui.Gui;
 import fr.zcraft.quartzlib.components.gui.GuiAction;
 import fr.zcraft.quartzlib.components.gui.PromptGui;
 import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
 import org.apache.commons.lang.ArrayUtils;
@@ -208,32 +209,35 @@ public class MapDetailGui extends ExplorerGui<Integer> {
             return;
         }
 
-        PromptGui.prompt(getPlayer(), newName -> {
-            if (!Permissions.RENAME.grantedTo(getPlayer())) {
-                I.sendT(getPlayer(), "{ce}You are no longer allowed to do that.");
-                return;
-            }
+        try {
+            PromptGui.prompt(getPlayer(), newName -> {
+                if (!Permissions.RENAME.grantedTo(getPlayer())) {
+                    I.sendT(getPlayer(), "{ce}You are no longer allowed to do that.");
+                    return;
+                }
 
-            if (newName == null || newName.isEmpty()) {
-                I.sendT(getPlayer(), "{ce}Map names can't be empty.");
-                return;
-            }
-            if (newName.equals(map.getName())) {
-                return;
-            }
+                if (newName == null || newName.isEmpty()) {
+                    I.sendT(getPlayer(), "{ce}Map names can't be empty.");
+                    return;
+                }
+                if (newName.equals(map.getName())) {
+                    return;
+                }
 
-            map.rename(newName);
-            I.sendT(getPlayer(), "{cs}Map successfully renamed.");
+                map.rename(newName);
+                I.sendT(getPlayer(), "{cs}Map successfully renamed.");
 
-            if (getParent() != null) {
-                RunTask.later(() -> Gui.open(getPlayer(), this), 1L);
+                if (getParent() != null) {
+                    RunTask.later(() -> Gui.open(getPlayer(), this), 1L);
 
-            } else {
-                close();
-            }
-        }, map.getName(), this);
+                } else {
+                    close();
+                }
+            }, map.getName(), this);
 
-
+        } catch (IllegalStateException e) {
+            PluginLogger.info("error while renaming");
+        }
     }
 
     @GuiAction("delete")

--- a/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
@@ -38,7 +38,6 @@ package fr.moribus.imageonmap.image;
 
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.PluginConfiguration;
-import fr.moribus.imageonmap.commands.IoMCommand;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.components.i18n.I;

--- a/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
+++ b/src/main/java/fr/moribus/imageonmap/image/ImageRendererExecutor.java
@@ -38,6 +38,7 @@ package fr.moribus.imageonmap.image;
 
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.PluginConfiguration;
+import fr.moribus.imageonmap.commands.IoMCommand;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.components.i18n.I;
@@ -98,6 +99,7 @@ public class ImageRendererExecutor extends Worker {
             public ImageMap run() throws Throwable {
 
                 BufferedImage image = null;
+
                 //If the link is an imgur one
                 if (url.toString().toLowerCase().startsWith("https://imgur.com/")) {
 
@@ -162,7 +164,6 @@ public class ImageRendererExecutor extends Worker {
         submitQuery(new WorkerRunnable<ImageMap>() {
             @Override
             public ImageMap run() throws Throwable {
-
                 final URLConnection connection = connecting(url);
 
                 final InputStream stream = connection.getInputStream();

--- a/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
+++ b/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
@@ -39,6 +39,7 @@ package fr.moribus.imageonmap.image;
 import fr.moribus.imageonmap.ImageOnMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.core.QuartzLib;
+import fr.zcraft.quartzlib.tools.runners.RunTask;
 import java.io.File;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -97,11 +98,14 @@ public class MapInitEvent implements Listener {
 
     @EventHandler
     public void onChunkLoad(ChunkLoadEvent event) {
-        for (Entity entity : event.getChunk().getEntities()) {
-            if (entity instanceof ItemFrame) {
-                initMap(((ItemFrame) entity).getItem());
+        //Fix for paper
+        RunTask.later(() -> {
+            for (Entity entity : event.getChunk().getEntities()) {
+                if (entity instanceof ItemFrame) {
+                    initMap(((ItemFrame) entity).getItem());
+                }
             }
-        }
+        }, 5L);
     }
 
     @EventHandler

--- a/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
+++ b/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
@@ -203,7 +203,6 @@ public class MapInitEvent implements Listener {
     @EventHandler
     public void onHangingBreakEvent(HangingBreakEvent event) {
         Entity entity = event.getEntity();
-        PluginLogger.info("entity " + entity.toString());
         if (!(entity instanceof ItemFrame)) {
             return;
         }

--- a/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
@@ -37,17 +37,16 @@
 package fr.moribus.imageonmap.ui;
 
 import fr.moribus.imageonmap.Permissions;
-import fr.moribus.imageonmap.PluginConfiguration;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.moribus.imageonmap.map.PosterMap;
 import fr.moribus.imageonmap.map.SingleMap;
 import fr.zcraft.quartzlib.components.i18n.I;
 import fr.zcraft.quartzlib.core.QuartzLib;
-import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
 import fr.zcraft.quartzlib.tools.items.ItemUtils;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
+import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Queue;
@@ -320,7 +319,6 @@ public class MapItemManager implements Listener {
                             || !SplatterMapManager.hasSplatterMap(player, poster)) {
                         poster.give(player);
                     }
-
                     return;
                 }
             }
@@ -329,7 +327,7 @@ public class MapItemManager implements Listener {
         if (!MapManager.managesMap(frame.getItem())) {
             return;
         }
-
+        SplatterMapManager.removePropertiesFromFrames(player, frame);
         frame.setItem(new ItemStackBuilder(item)
                 .title(getMapTitle(item))
                 .hideAllAttributes()

--- a/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
@@ -137,6 +137,7 @@ public abstract class SplatterMapManager {
      * @return True if the attribute was detected.
      */
     public static boolean hasSplatterAttributes(ItemStack itemStack) {
+
         try {
             final NBTCompound nbt = NBT.fromItemStack(itemStack);
             if (!nbt.containsKey("Enchantments")) {

--- a/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
@@ -65,7 +65,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.MapMeta;
 
-
+//TODO rework splatter effect, using ID is far more stable than nbt tags.
+// To update when adding small picture previsualization.
 public abstract class SplatterMapManager {
     private SplatterMapManager() {
     }

--- a/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
@@ -37,6 +37,7 @@
 package fr.moribus.imageonmap.ui;
 
 import com.google.common.collect.ImmutableMap;
+import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.image.MapInitEvent;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
@@ -53,6 +54,7 @@ import fr.zcraft.quartzlib.tools.runners.RunTask;
 import fr.zcraft.quartzlib.tools.text.MessageSender;
 import fr.zcraft.quartzlib.tools.world.FlatLocation;
 import fr.zcraft.quartzlib.tools.world.WorldUtils;
+import java.lang.reflect.Method;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -242,6 +244,7 @@ public abstract class SplatterMapManager {
                 //Rotation management relative to player rotation the default position is North,
                 // when on ceiling we flipped the rotation
                 RunTask.later(() -> {
+                    addPropertiesToFrames(player, frame);
                     frame.setItem(
                             new ItemStackBuilder(Material.FILLED_MAP).nbt(ImmutableMap.of("map", id)).craftItem());
                 }, 5L);
@@ -303,6 +306,7 @@ public abstract class SplatterMapManager {
                 int id = poster.getMapIdAtReverseY(i);
 
                 RunTask.later(() -> {
+                    addPropertiesToFrames(player, frame);
                     frame.setItem(
                             new ItemStackBuilder(Material.FILLED_MAP).nbt(ImmutableMap.of("map", id)).craftItem());
                 }, 5L);
@@ -361,10 +365,31 @@ public abstract class SplatterMapManager {
 
         for (ItemFrame frame : matchingFrames) {
             if (frame != null) {
+                removePropertiesFromFrames(player, frame);
                 frame.setItem(null);
             }
         }
 
         return poster;
+    }
+
+    public static void addPropertiesToFrames(Player player, ItemFrame frame) {
+        if (Permissions.PLACE_INVISIBLE_SPLATTER_MAP.grantedTo(player)) {
+            try {
+                Method setVisible = frame.getClass().getMethod("setVisible", boolean.class);
+                setVisible.invoke(frame, false);
+            } catch (Exception e) {
+                //1.16-
+            }
+        }
+    }
+
+    public static void removePropertiesFromFrames(Player player, ItemFrame frame) {
+        try {
+            Method setVisible = frame.getClass().getMethod("setVisible", boolean.class);
+            setVisible.invoke(frame, true);
+        } catch (Exception e) {
+            //1.16-
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,3 +26,6 @@ limit-map-size-y: 0
 # Should the full image be saved when a map is rendered?
 save-full-image: false
 
+# Give the name of trusted image hosting website
+#Example allowlist_hostingsite: https://imgur.com/, https://i.imgur.com/, https://cdn.discordapp.com
+allowlist_hostingsite:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,6 +41,8 @@ permissions:
       imageonmap.bypassmaplimit: false
       imageonmap.bypassimagelimit: false
       imageonmap.ignoreallowlist_hostingsite: true
+      imageonmap.placeinvisiblesplattermap: true
+
   imageonmap.userender:
     description: "Allows you to use /tomap and related commands (/maptool getremaining). Alias of imageonmap.new."
     default: true
@@ -123,4 +125,8 @@ permissions:
 
   imageonmap.ignoreallowlist_hostingsite:
     description: "Allows you to ignore the restriction on the allow list for image hosting website."
+    default: true
+
+  imageonmap.placeinvisiblesplattermap:
+    description: "Allows you to make the item frame on which you placed your splatter map invisible."
     default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,6 +38,8 @@ permissions:
       imageonmap.give: false
       imageonmap.update: true
       imageonmap.updateother: false
+      imageonmap.bypassmaplimit: false
+      imageonmap.bypassimagelimit: false
 
   imageonmap.userender:
     description: "Allows you to use /tomap and related commands (/maptool getremaining). Alias of imageonmap.new."
@@ -109,4 +111,12 @@ permissions:
 
   imageonmap.updateother:
     description: "Allows you to update an existing map of an other player with a new image."
+    default: op
+
+  imageonmap.bypassmaplimit:
+    description: "Allows you to bypass permission node check for the number of used map (by default users have an unlimited amount of maps)."
+    default: op
+
+  imageonmap.bypassimagelimit:
+    description: "Allows you to bypass permission node check for the number of images in the playerMapStore(by default users have an unlimited amount of images)."
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ImageOnMap
 main: fr.moribus.imageonmap.ImageOnMap
-version: "4.1.2"
+version: "4.2.0"
 api-version: "1.13"
 
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -40,7 +40,7 @@ permissions:
       imageonmap.updateother: false
       imageonmap.bypassmaplimit: false
       imageonmap.bypassimagelimit: false
-
+      imageonmap.ignoreallowlist_hostingsite: true
   imageonmap.userender:
     description: "Allows you to use /tomap and related commands (/maptool getremaining). Alias of imageonmap.new."
     default: true
@@ -118,5 +118,9 @@ permissions:
     default: op
 
   imageonmap.bypassimagelimit:
-    description: "Allows you to bypass permission node check for the number of images in the playerMapStore(by default users have an unlimited amount of images)."
+    description: "Allows you to bypass permission node check for the number of images in the playerMapStore (by default users have an unlimited amount of images)."
     default: op
+
+  imageonmap.ignoreallowlist_hostingsite:
+    description: "Allows you to ignore the restriction on the allow list for image hosting website."
+    default: true


### PR DESCRIPTION
Main changes are on QL side, the only ones are:

- [x] - 1.17 support
- [x] - Dropped migrator (no more error when reloading)
- [x] - Fixed an issue when resizing with resize 0 0 (that wasn't working properly)
- [x] - Added a fix for map loading on paper. (map did not render fully on paper)
- [x] - Fixed a map loading issue.  (map did not render at all if they weren't in a player inventory
- [x] - #154 nodes to limit the number of map/image used/owned is now possible. (permissions imageonmap.mapLimit.XX and imageonmap.imageLimit.XX where XX is an integer and will define the limit allowed for the player)
- [x] - Added an allow list for trusted image hosting website (Add this in config.yml allowlist_hostingsite: , you then have to put the url of trusted websites. There is also a permission to ignore the allow list imageonmap.ignoreallowlist_hostingsite)
- [x] - Images are now protected against non player based interaction. (Bye bye sneaky skeleton that used to grief art)
- [x] - Now by default when deploying a map the item frame turn invisible and returned to visible hen removing the map from the frame (there is a permission to allow this behaviour) 
