### PR TITLE
Edited Readme and fixed a lag issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ This version fixes some small console spam bugs and improves the performance of 
 Permission and cliffhanger Update finally allow a full official support of minecraft 1.17 and java 17. This comes with bugfixes and new features. We are working on the next big update that will be the 5.0. If you want to know more about this checkout our 5.0 milestone.
 
 This version is only compatible with Minecraft 1.15+. We have no clue if this will work with minecraft 1.18 (it should, but we are not sure)
-This was tested on Paper 1.17, 1.16 and spigot 1.17,1.15. If there are any errors on a 1.15+ version of spigot/paper please contact us on our discord or create a ticket on the issues page (better)
+This was tested on Paper 1.17, 1.16 and spigot 1.17, 1.15. If there are any errors on a 1.15+ version of spigot/paper please contact us on our discord or create a ticket on the issues page (better)
 
 - 1.17 support
+  
 - Permissions to limit the number of map/image used/owned is now possible. (permissions imageonmap.mapLimit.XX and imageonmap.imageLimit.XX where XX is an integer and will define the limit allowed for the player)
 
 - Added an allowlist for trusted image hosting website (Add this in config.yml allowlist_hostingsite: , you then have to put the url of trusted websites. There is also a permission to ignore the allow list imageonmap.ignoreallowlist_hostingsite)
@@ -231,7 +232,15 @@ This was tested on Paper 1.17, 1.16 and spigot 1.17,1.15. If there are any error
   - Added a fix for map loading on paper. (map did not render fully on paper)
 
 ### 4.2.1 — The permission and cliffhanger part 1 Update Two
+
 - Fixed a lag issue caused by the map loading changes of 4.2.0
+
+- 1.18 support
+
+- Fixed an issue with map part not working properly 
+
+- Fixed an issue in survival where an incorrect amount of map were consumed
+
 ## Data collection
 
 We use metrics to collect [basic information about the usage of this plugin](https://bstats.org/plugin/bukkit/ImageOnMap).

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ This was tested on Paper 1.17, 1.16 and spigot 1.17, 1.15. If there are any erro
 
 - Fixed an issue in survival where an incorrect amount of map were consumed
 
+- Fixed an issue where image map folder was not created and cause issues
+
 ## Data collection
 
 We use metrics to collect [basic information about the usage of this plugin](https://bstats.org/plugin/bukkit/ImageOnMap).

--- a/README.md
+++ b/README.md
@@ -209,6 +209,29 @@ This version fixes some small console spam bugs and improves the performance of 
 - Updates to [QuartzLib 0.0.4](https://github.com/zDevelopers/QuartzLib/blob/master/CHANGELOG.md#quartzlib-004),
   where all these improvements were made.
 
+### 4.2.0 —The permission and cliffhanger part 1 Update
+Permission and cliffhanger Update finally allow a full official support of minecraft 1.17 and java 17. This comes with bugfixes and new features. We are working on the next big update that will be the 5.0. If you want to know more about this checkout our 5.0 milestone.
+
+This version is only compatible with Minecraft 1.15+. We have no clue if this will work with minecraft 1.18 (it should, but we are not sure)
+This was tested on Paper 1.17, 1.16 and spigot 1.17,1.15. If there are any errors on a 1.15+ version of spigot/paper please contact us on our discord or create a ticket on the issues page (better)
+
+- 1.17 support
+- Permissions to limit the number of map/image used/owned is now possible. (permissions imageonmap.mapLimit.XX and imageonmap.imageLimit.XX where XX is an integer and will define the limit allowed for the player)
+
+- Added an allowlist for trusted image hosting website (Add this in config.yml allowlist_hostingsite: , you then have to put the url of trusted websites. There is also a permission to ignore the allow list imageonmap.ignoreallowlist_hostingsite)
+
+- Images are now protected against non player based interaction. (Bye bye sneaky skeleton that used to grief art)
+
+- Now by default when deploying a map the item frame turn invisible and returned to visible hen removing the map from the frame (there is a permission to allow this behaviour imageonmap.placeinvisiblesplattermap)
+
+- Bug fixes & optimizations.
+  - Dropped migrator (no more error when reloading or when sometimes loading the server)
+  - Fixed an issue when resizing with resize 0 0
+  - Fixed a map loading issue. (map did not render at all if they weren't in a player inventory
+  - Added a fix for map loading on paper. (map did not render fully on paper)
+
+### 4.2.1 — The permission and cliffhanger part 1 Update Two
+- Fixed a lag issue caused by the map loading changes of 4.2.0
 ## Data collection
 
 We use metrics to collect [basic information about the usage of this plugin](https://bstats.org/plugin/bukkit/ImageOnMap).

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.moribus</groupId>
     <artifactId>ImageOnMap</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>fr.zcraft</groupId>
             <artifactId>quartzlib</artifactId>
-            <version>0.0.4</version>
+            <version>0.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -103,6 +103,7 @@ public final class ImageOnMap extends QuartzPlugin {
         try {
             //imagesDirectory = checkPluginDirectory(imagesDirectory, V3Migrator.getOldImagesDirectory(this));
             checkPluginDirectory(mapsDirectory);
+            checkPluginDirectory(imagesDirectory);
         } catch (final IOException ex) {
             PluginLogger.error("FATAL: " + ex.getMessage());
             this.setEnabled(false);

--- a/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
+++ b/src/main/java/fr/moribus/imageonmap/image/MapInitEvent.java
@@ -46,8 +46,8 @@ import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
 import java.io.File;
+import java.util.List;
 import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -227,21 +227,7 @@ public class MapInitEvent implements Listener {
             //Used to make sure map are really loaded in 1.17 on Paper (else some won't render or update properly)
             RunTask.later(() -> {
                 try {
-                    Chunk chunk = (Chunk) Reflection.call(event.getEvent(), "getChunk");
-                    Entity[] entities = chunk.getEntities();
-                    //Not the most efficient method because we go through entity already loaded
-
-                    //The direct method using getEntities of
-                    // https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/world/EntitiesLoadEvent.html
-                    //Return an unmodifiable list of entities.
-                    //Using this make the overall process a bit more efficient but way more complicated and very weak
-                    // to change.
-                    //TODO Investigate if there is a better way to do this.
-                    //Early exit, most are empty entities array
-                    if (entities.length == 0) {
-                        return;
-                    }
-
+                    List<Entity> entities = (List) Reflection.call(event.getEvent(), "getEntities");
                     for (Entity entity : entities) {
                         if (entity instanceof ItemFrame) {
                             initMap(((ItemFrame) entity).getItem());

--- a/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
@@ -288,7 +288,7 @@ public class MapItemManager implements Listener {
             }, 5L);
 
         }
-        ItemUtils.consumeItem(player, mapItem); //useless no?
+        //ItemUtils.consumeItem(player, mapItem); //useless no?
     }
 
     private static void onItemFrameRemove(ItemFrame frame, Player player, EntityDamageByEntityEvent event) {

--- a/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
@@ -43,10 +43,10 @@ import fr.moribus.imageonmap.map.PosterMap;
 import fr.moribus.imageonmap.map.SingleMap;
 import fr.zcraft.quartzlib.components.i18n.I;
 import fr.zcraft.quartzlib.core.QuartzLib;
+import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
 import fr.zcraft.quartzlib.tools.items.ItemUtils;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
-import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Queue;
@@ -262,6 +262,7 @@ public class MapItemManager implements Listener {
         frame.setItem(new ItemStack(Material.AIR));
         if (SplatterMapManager.hasSplatterAttributes(mapItem)) {
             if (!SplatterMapManager.placeSplatterMap(frame, player, event)) {
+
                 event.setCancelled(true); //In case of an error allow to cancel map placement
                 return;
             }
@@ -274,33 +275,20 @@ public class MapItemManager implements Listener {
             if (frame.getFacing() != BlockFace.UP && frame.getFacing() != BlockFace.DOWN) {
                 frame.setRotation(Rotation.NONE);
             }
-            // If the item has a display name, bot not one from an anvil by the player, we remove it
-            // If it is not displayed on hover on the wall.
-            if (mapItem.hasItemMeta() && mapItem.getItemMeta().hasDisplayName()
-                    && mapItem.getItemMeta().getDisplayName().startsWith("§6")) {
-                //runtask
-                //TODO utiliser run task.later pour essayer de regler le pb d'itemframe bas gauche sans carte
-                final ItemStack frameItem = mapItem.clone();
-                final ItemMeta meta = frameItem.getItemMeta();
 
-                meta.setDisplayName(null);
-                frameItem.setItemMeta(meta);
-                RunTask.later(() -> {
-                    frame.setItem(frameItem);
-                    frame.setRotation(Rotation.NONE);
-                }, 5L);
 
-            } else {
+            final ItemStack frameItem = mapItem.clone();
+            final ItemMeta meta = frameItem.getItemMeta();
+
+            meta.setDisplayName(null);
+            frameItem.setItemMeta(meta);
+            RunTask.later(() -> {
+                frame.setItem(frameItem);
                 frame.setRotation(Rotation.NONE);
-                RunTask.later(() -> {
-                    frame.setItem(mapItem);
-                }, 5L);
-
-            }
+            }, 5L);
 
         }
-
-        ItemUtils.consumeItem(player, mapItem);
+        ItemUtils.consumeItem(player, mapItem); //useless no?
     }
 
     private static void onItemFrameRemove(ItemFrame frame, Player player, EntityDamageByEntityEvent event) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ImageOnMap
 main: fr.moribus.imageonmap.ImageOnMap
-version: "4.2.0"
+version: "4.2.1"
 api-version: "1.13"
 
 


### PR DESCRIPTION
Updated ReadMe file and added a fix for a  lag issue reported in #221 Quick test with spark show that the getEntities() is no longer a lag source. Waiting for reporter (Eris on discord) returns to see if this has solved the issue.

Also fixed two issues concerning wrong map consuming when on survival and map part disapearing when placed