### PR TITLE
Update for 1.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+
+# macOS Metadata files
+.DS_STORE
+.icloud

--- a/licenseheader.txt
+++ b/licenseheader.txt
@@ -5,6 +5,7 @@ ${licensePrefix}Copyright or © or Copr. Moribus (2013)
 ${licensePrefix}Copyright or © or Copr. ProkopyL <prokopylmc@gmail.com> (2015)
 ${licensePrefix}Copyright or © or Copr. Amaury Carrade <amaury@carrade.eu> (2016 – 2021)
 ${licensePrefix}Copyright or © or Copr. Vlammar <valentin.jabre@gmail.com> (2019 – 2021)
+${licensePrefix}Copyright or © or Copr. <me@foxt.dev> (2021)
 ${licensePrefix?replace(" +$", "", "r")}
 ${licensePrefix}This software is a computer program whose purpose is to allow insertion of
 ${licensePrefix}custom images in a Minecraft word.

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.moribus</groupId>
     <artifactId>ImageOnMap</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -101,7 +101,7 @@ public final class ImageOnMap extends QuartzPlugin {
     public void onEnable() {
         // Creating the images and maps directories if necessary
         try {
-            //imagesDirectory = checkPluginDirectory(imagesDirectory, V3Migrator.getOldImagesDirectory(this));
+            imagesDirectory = checkPluginDirectory(imagesDirectory);
             checkPluginDirectory(mapsDirectory);
         } catch (final IOException ex) {
             PluginLogger.error("FATAL: " + ex.getMessage());
@@ -140,7 +140,7 @@ public final class ImageOnMap extends QuartzPlugin {
         Commands.registerShortcut("maptool", NewCommand.class, "tomap");
         Commands.registerShortcut("maptool", ExploreCommand.class, "maps");
         Commands.registerShortcut("maptool", GiveCommand.class, "givemap");
-
+        /*
         if (PluginConfiguration.CHECK_FOR_UPDATES.get()) {
             UpdateChecker.boot("imageonmap.26585");
         }
@@ -151,7 +151,7 @@ public final class ImageOnMap extends QuartzPlugin {
             metrics.addCustomChart(new Metrics.SingleLineChart("used-minecraft-maps", MapManager::getMapCount));
         } else {
             PluginLogger.warning("Collect data disabled");
-        }
+        }*/
     }
 
     @Override

--- a/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/MapItemManager.java
@@ -3,6 +3,7 @@
  * Copyright or © or Copr. ProkopyL <prokopylmc@gmail.com> (2015)
  * Copyright or © or Copr. Amaury Carrade <amaury@carrade.eu> (2016 – 2021)
  * Copyright or © or Copr. Vlammar <valentin.jabre@gmail.com> (2019 – 2021)
+ * Copyright or © or Copr. <me@foxt.dev> (2021)
  *
  * This software is a computer program whose purpose is to allow insertion of
  * custom images in a Minecraft world.
@@ -46,7 +47,6 @@ import fr.zcraft.quartzlib.core.QuartzLib;
 import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
 import fr.zcraft.quartzlib.tools.items.ItemUtils;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
-import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Queue;
@@ -163,19 +163,18 @@ public class MapItemManager implements Listener {
     }
 
     public static ItemStack createMapItem(int mapID, String text, boolean isMapPart, boolean goldTitle) {
-        ItemStack mapItem;
-        if (goldTitle) {
-            mapItem = new ItemStackBuilder(Material.FILLED_MAP)
-                    .title(ChatColor.GOLD, text)
-                    .hideAllAttributes()
-                    .item();
-        } else {
-            mapItem = new ItemStackBuilder(Material.FILLED_MAP)
-                    .title(text)
-                    .hideAllAttributes()
-                    .item();
-        }
+        ItemStack mapItem = new ItemStackBuilder(Material.FILLED_MAP)
+                .hideAllAttributes()
+                .item();
+
         final MapMeta meta = (MapMeta) mapItem.getItemMeta();
+        if (text != "null") {
+            if (goldTitle) {
+                meta.setDisplayName("§" + ChatColor.GOLD + text);
+            } else {
+                meta.setDisplayName(text);
+            }
+        }
         meta.setMapId(mapID);
         meta.setColor(isMapPart ? Color.LIME : Color.GREEN);
         mapItem.setItemMeta(meta);
@@ -252,7 +251,7 @@ public class MapItemManager implements Listener {
         if (!MapManager.managesMap(mapItem)) {
             return;
         }
-
+        
         if (!Permissions.PLACE_SPLATTER_MAP.grantedTo(player)) {
             player.sendMessage(I.t(ChatColor.RED + "You do not have permission to place splatter maps."));
             event.setCancelled(true);

--- a/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
@@ -3,6 +3,7 @@
  * Copyright or © or Copr. ProkopyL <prokopylmc@gmail.com> (2015)
  * Copyright or © or Copr. Amaury Carrade <amaury@carrade.eu> (2016 – 2021)
  * Copyright or © or Copr. Vlammar <valentin.jabre@gmail.com> (2019 – 2021)
+ * Copyright or © or Copr. <me@foxt.dev> (2021)
  *
  * This software is a computer program whose purpose is to allow insertion of
  * custom images in a Minecraft world.
@@ -36,22 +37,15 @@
 
 package fr.moribus.imageonmap.ui;
 
-import com.google.common.collect.ImmutableMap;
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.image.MapInitEvent;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.moribus.imageonmap.map.PosterMap;
 import fr.zcraft.quartzlib.components.i18n.I;
-import fr.zcraft.quartzlib.components.nbt.NBT;
-import fr.zcraft.quartzlib.components.nbt.NBTCompound;
-import fr.zcraft.quartzlib.components.nbt.NBTList;
-import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.items.GlowEffect;
 import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
-import fr.zcraft.quartzlib.tools.reflection.NMSException;
 import fr.zcraft.quartzlib.tools.runners.RunTask;
-import fr.zcraft.quartzlib.tools.text.MessageSender;
 import fr.zcraft.quartzlib.tools.world.FlatLocation;
 import fr.zcraft.quartzlib.tools.world.WorldUtils;
 import java.lang.reflect.Method;
@@ -140,21 +134,7 @@ public abstract class SplatterMapManager {
      * @return True if the attribute was detected.
      */
     public static boolean hasSplatterAttributes(ItemStack itemStack) {
-
-        try {
-            final NBTCompound nbt = NBT.fromItemStack(itemStack);
-            if (!nbt.containsKey("Enchantments")) {
-                return false;
-            }
-            final Object enchantments = nbt.get("Enchantments");
-            if (!(enchantments instanceof NBTList)) {
-                return false;
-            }
-            return !((NBTList) enchantments).isEmpty();
-        } catch (NMSException e) {
-            PluginLogger.error("Unable to get Splatter Map attribute on item", e);
-            return false;
-        }
+        return GlowEffect.hasGlow(itemStack);
     }
 
     /**
@@ -218,10 +198,9 @@ public abstract class SplatterMapManager {
             surface.loc2 = endLocation;
 
             if (!surface.isValid(player)) {
-                MessageSender.sendActionBarMessage(player,
+                player.sendMessage(
                         I.t("{ce}There is not enough space to place this map ({0} × {1}).",
-                                poster.getColumnCount(),
-                                poster.getRowCount()));
+                                poster.getColumnCount(),  poster.getRowCount()));
 
 
                 return false;
@@ -245,8 +224,10 @@ public abstract class SplatterMapManager {
                 // when on ceiling we flipped the rotation
                 RunTask.later(() -> {
                     addPropertiesToFrames(player, frame);
-                    frame.setItem(
-                            new ItemStackBuilder(Material.FILLED_MAP).nbt(ImmutableMap.of("map", id)).craftItem());
+                    ItemStack mapItem = MapItemManager.createMapItem(id, null,true);
+                    MapMeta meta = (MapMeta) mapItem.getItemMeta();
+                    mapItem.setItemMeta(meta);
+                    frame.setItem(mapItem);
                 }, 5L);
 
                 if (i == 0) {
@@ -294,7 +275,7 @@ public abstract class SplatterMapManager {
             wall.loc2 = endLocation;
 
             if (!wall.isValid()) {
-                MessageSender.sendActionBarMessage(player,
+                player.sendMessage(
                         I.t("{ce}There is not enough space to place this map ({0} × {1}).", poster.getColumnCount(),
                                 poster.getRowCount()));
                 return false;
@@ -307,8 +288,10 @@ public abstract class SplatterMapManager {
 
                 RunTask.later(() -> {
                     addPropertiesToFrames(player, frame);
-                    frame.setItem(
-                            new ItemStackBuilder(Material.FILLED_MAP).nbt(ImmutableMap.of("map", id)).craftItem());
+                    ItemStack mapItem = MapItemManager.createMapItem(id, null,true);
+                    MapMeta meta = (MapMeta) mapItem.getItemMeta();
+                    mapItem.setItemMeta(meta);
+                    frame.setItem(mapItem);
                 }, 5L);
 
 

--- a/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/ui/SplatterMapManager.java
@@ -224,10 +224,7 @@ public abstract class SplatterMapManager {
                 // when on ceiling we flipped the rotation
                 RunTask.later(() -> {
                     addPropertiesToFrames(player, frame);
-                    ItemStack mapItem = MapItemManager.createMapItem(id, null,true);
-                    MapMeta meta = (MapMeta) mapItem.getItemMeta();
-                    mapItem.setItemMeta(meta);
-                    frame.setItem(mapItem);
+                    frame.setItem(MapItemManager.createMapItem(id, null,true));
                 }, 5L);
 
                 if (i == 0) {
@@ -288,10 +285,7 @@ public abstract class SplatterMapManager {
 
                 RunTask.later(() -> {
                     addPropertiesToFrames(player, frame);
-                    ItemStack mapItem = MapItemManager.createMapItem(id, null,true);
-                    MapMeta meta = (MapMeta) mapItem.getItemMeta();
-                    mapItem.setItemMeta(meta);
-                    frame.setItem(mapItem);
+                    frame.setItem(MapItemManager.createMapItem(id, null,true));
                 }, 5L);
 
 


### PR DESCRIPTION
Tested in Paper 1.18.1 and it worked fine on our server. If there's any issues I didn't catch, please be careful, I'm a Java/Bukkit n00b 😅 

 - Newer versions of the CraftBukkit API throw errors when trying to access raw NBT data. This PR updates the broken functions for splatter maps that don't work on modern versions.
 - Plugin doesn't ensure that the images folder existing, which will cause all map art to be lost on server restart.
 - Some bossbar messages are replaced with chat messages as they didn't work in my testing.