### PR TITLE
Add Vault support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,13 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+
+        <!-- VaultAPI -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+
     </repositories>
 
     <dependencies>
@@ -141,6 +148,12 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>1.8</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+        <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
+++ b/src/main/java/fr/moribus/imageonmap/ImageOnMap.java
@@ -46,6 +46,7 @@ import fr.moribus.imageonmap.commands.maptool.ListCommand;
 import fr.moribus.imageonmap.commands.maptool.NewCommand;
 import fr.moribus.imageonmap.commands.maptool.RenameCommand;
 import fr.moribus.imageonmap.commands.maptool.UpdateCommand;
+import fr.moribus.imageonmap.economy.EconomyComponent;
 import fr.moribus.imageonmap.image.ImageIOExecutor;
 import fr.moribus.imageonmap.image.ImageRendererExecutor;
 import fr.moribus.imageonmap.image.MapInitEvent;
@@ -113,8 +114,15 @@ public final class ImageOnMap extends QuartzPlugin {
 
         saveDefaultConfig();
         commandWorker = loadComponent(CommandWorkers.class);
-        loadComponents(I18n.class, Gui.class, Commands.class, PluginConfiguration.class, ImageIOExecutor.class,
-                ImageRendererExecutor.class);
+        loadComponents(
+                I18n.class, 
+                Gui.class, 
+                Commands.class, 
+                PluginConfiguration.class, 
+                ImageIOExecutor.class,
+                ImageRendererExecutor.class,
+                EconomyComponent.class
+        );
 
         //Init all the things !
         I18n.setPrimaryLocale(PluginConfiguration.LANG.get());
@@ -122,6 +130,7 @@ public final class ImageOnMap extends QuartzPlugin {
         MapManager.init();
         MapInitEvent.init();
         MapItemManager.init();
+        EconomyComponent.init();
 
 
         Commands.register(

--- a/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
+++ b/src/main/java/fr/moribus/imageonmap/PluginConfiguration.java
@@ -64,4 +64,9 @@ public final class PluginConfiguration extends Configuration {
     public static ConfigurationList<String> IMAGES_HOSTNAMES_WHITELIST =
             list("images-hostnames-whitelist", String.class);
 
+    public static ConfigurationItem<Boolean> ENABLE_ECONOMY = item("enable-economy", false);
+    public static ConfigurationItem<Boolean> SCALE_MAP_COST = item("scale-map-cost", true);
+    public static ConfigurationItem<Integer> COST_PER_MAP = item("cost-per-map", 100);
+    public static ConfigurationItem<Boolean> SCALE_COPY_COST = item("scale-copy-cost", false);
+    public static ConfigurationItem<Integer> COST_PER_COPY = item("cost-per-copy", 50);
 }

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GetCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GetCommand.java
@@ -39,6 +39,8 @@ package fr.moribus.imageonmap.commands.maptool;
 import fr.moribus.imageonmap.ImageOnMap;
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.components.commands.CommandException;
@@ -96,10 +98,19 @@ public class GetCommand extends IoMCommand {
                 return;
             }
 
-            if (map.give(sender)) {
-                info(I.t("The requested map was too big to fit in your inventory."));
-                info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+            try {
+                if (map.give(sender)) {
+                    info(I.t("The requested map was too big to fit in your inventory."));
+                    info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                }
+            } catch (EconomyNotEnabledException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            } catch (InsufficientFundsException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
             }
+            
         });
     }
 

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GetRemainingCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GetRemainingCommand.java
@@ -38,6 +38,8 @@ package fr.moribus.imageonmap.commands.maptool;
 
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.ui.MapItemManager;
 import fr.zcraft.quartzlib.components.commands.CommandException;
 import fr.zcraft.quartzlib.components.commands.CommandInfo;
@@ -56,14 +58,25 @@ public class GetRemainingCommand extends IoMCommand {
             return;
         }
 
-        int givenMaps = MapItemManager.giveCache(player);
-
-        if (givenMaps == 0) {
-            error(I.t("Your inventory is full! Make some space before requesting the remaining maps."));
-        } else {
-            info(I.tn("There is {0} map remaining.", "There are {0} maps remaining.",
-                    MapItemManager.getCacheSize(player)));
+        try {
+            int givenMaps = MapItemManager.giveCache(player);
+            if (givenMaps == 0) {
+                error(I.t("Your inventory is full! Make some space before requesting the remaining maps."));
+            } else {
+                info(I.tn(
+                        "There is {0} map remaining.", "There are {0} maps remaining.",
+                        MapItemManager.getCacheSize(player)
+                ));
+            }
+        } catch (EconomyNotEnabledException exception) {
+            // TODO Auto-generated catch block
+            exception.printStackTrace();
+        } catch (InsufficientFundsException exception) {
+            // TODO Auto-generated catch block
+            exception.printStackTrace();
         }
+
+        
     }
 
     @Override

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/GiveCommand.java
@@ -38,6 +38,8 @@ package fr.moribus.imageonmap.commands.maptool;
 
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.zcraft.quartzlib.components.commands.CommandException;
@@ -111,11 +113,21 @@ public class GiveCommand extends IoMCommand {
             }
 
             retrieveUUID(playerName, uuid2 -> {
-                if (Bukkit.getPlayer((uuid2)) != null && Bukkit.getPlayer((uuid2)).isOnline()
-                        && map.give(Bukkit.getPlayer(uuid2))) {
-                    info(I.t("The requested map was too big to fit in your inventory."));
-                    info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                
+                try {
+                    if (Bukkit.getPlayer((uuid2)) != null && Bukkit.getPlayer((uuid2)).isOnline()
+                            && map.give(Bukkit.getPlayer(uuid2))) {
+                        info(I.t("The requested map was too big to fit in your inventory."));
+                        info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                    }
+                } catch (EconomyNotEnabledException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                } catch (InsufficientFundsException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
                 }
+
             });
         });
 

--- a/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
+++ b/src/main/java/fr/moribus/imageonmap/commands/maptool/NewCommand.java
@@ -37,7 +37,10 @@
 package fr.moribus.imageonmap.commands.maptool;
 
 import fr.moribus.imageonmap.Permissions;
+import fr.moribus.imageonmap.PluginConfiguration;
 import fr.moribus.imageonmap.commands.IoMCommand;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.image.ImageRendererExecutor;
 import fr.moribus.imageonmap.image.ImageUtils;
 import fr.moribus.imageonmap.map.ImageMap;
@@ -162,11 +165,20 @@ public class NewCommand extends IoMCommand {
                             MessageSender
                                     .sendActionBarMessage(player, ChatColor.DARK_GREEN + I.t("Rendering finished!"));
 
-                            if (result.give(player)
-                                    && (result instanceof PosterMap && !((PosterMap) result).hasColumnData())) {
-                                info(I.t("The rendered map was too big to fit in your inventory."));
-                                info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                            try {
+                                if (result.give(player)
+                                        && (result instanceof PosterMap && !((PosterMap) result).hasColumnData())) {
+                                    info(I.t("The rendered map was too big to fit in your inventory."));
+                                    info(I.t("Use '/maptool getremaining' to get the remaining maps."));
+                                }
+                            } catch (EconomyNotEnabledException e) {
+                                // TODO Auto-generated catch block
+                                e.printStackTrace();
+                            } catch (InsufficientFundsException e) {
+                                // TODO Auto-generated catch block
+                                e.printStackTrace();
                             }
+                            
                         }
 
                         @Override

--- a/src/main/java/fr/moribus/imageonmap/economy/EconomyComponent.java
+++ b/src/main/java/fr/moribus/imageonmap/economy/EconomyComponent.java
@@ -1,0 +1,34 @@
+package fr.moribus.imageonmap.economy;
+
+import fr.moribus.imageonmap.PluginConfiguration;
+import fr.zcraft.quartzlib.core.QuartzComponent;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public final class EconomyComponent extends QuartzComponent {
+
+    private static Economy economy = null;
+
+    public static void init() {
+        System.out.println("HELLO!");
+        if (PluginConfiguration.ENABLE_ECONOMY.get() 
+                && Bukkit.getPluginManager().getPlugin("Vault") != null) {
+            RegisteredServiceProvider<Economy> rsp = Bukkit.getServicesManager().getRegistration(Economy.class);
+            if (rsp != null) {
+                economy = rsp.getProvider();
+            }
+        }
+    }
+
+    public static Economy getEconomy() throws EconomyNotEnabledException {
+
+        if (economy != null) {
+            return economy;
+        } else {
+            throw new EconomyNotEnabledException();
+        }
+
+    }
+
+}

--- a/src/main/java/fr/moribus/imageonmap/economy/EconomyNotEnabledException.java
+++ b/src/main/java/fr/moribus/imageonmap/economy/EconomyNotEnabledException.java
@@ -1,0 +1,9 @@
+package fr.moribus.imageonmap.economy;
+
+public class EconomyNotEnabledException extends Exception {
+    
+    public EconomyNotEnabledException() {
+        super("The economy is disabled");
+    }
+    
+}

--- a/src/main/java/fr/moribus/imageonmap/economy/InsufficientFundsException.java
+++ b/src/main/java/fr/moribus/imageonmap/economy/InsufficientFundsException.java
@@ -1,0 +1,24 @@
+package fr.moribus.imageonmap.economy;
+
+import org.bukkit.OfflinePlayer;
+
+public class InsufficientFundsException extends Exception {
+
+    private final OfflinePlayer player;
+    private final double cost;
+
+    public InsufficientFundsException(OfflinePlayer player, double cost) {
+        super("Insufficient funds");
+        this.player = player;
+        this.cost = cost;
+    }
+
+    public OfflinePlayer getPlayer() {
+        return player;
+    }
+
+    public double getCost() {
+        return cost;
+    } 
+
+}

--- a/src/main/java/fr/moribus/imageonmap/gui/MapListGui.java
+++ b/src/main/java/fr/moribus/imageonmap/gui/MapListGui.java
@@ -38,6 +38,8 @@ package fr.moribus.imageonmap.gui;
 
 import fr.moribus.imageonmap.Permissions;
 import fr.moribus.imageonmap.PluginConfiguration;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.map.ImageMap;
 import fr.moribus.imageonmap.map.MapManager;
 import fr.moribus.imageonmap.map.PosterMap;
@@ -143,25 +145,37 @@ public class MapListGui extends ExplorerGui<ImageMap> {
 
     @Override
     protected ItemStack getPickedUpItem(ImageMap map) {
-        if (!Permissions.GET.grantedTo(getPlayer())) {
-            return null;
-        }
 
-        if (map instanceof SingleMap) {
-            return MapItemManager.createMapItem(map.getMapsIDs()[0], map.getName(), false, true);
-        } else if (map instanceof PosterMap) {
-            PosterMap poster = (PosterMap) map;
+        try {
 
-            if (poster.hasColumnData()) {
-                return SplatterMapManager.makeSplatterMap((PosterMap) map);
+            if (!Permissions.GET.grantedTo(getPlayer())) {
+                return null;
             }
 
-            MapItemManager.giveParts(getPlayer(), poster);
-            return null;
-        }
+            if (map instanceof SingleMap) {
+                return MapItemManager.createMapItem(map.getMapsIDs()[0], map.getName(), false, true);
+            } else if (map instanceof PosterMap) {
+                PosterMap poster = (PosterMap) map;
 
-        MapItemManager.give(getPlayer(), map);
+                if (poster.hasColumnData()) {
+                    return SplatterMapManager.makeSplatterMap((PosterMap) map);
+                }
+
+                MapItemManager.giveParts(getPlayer(), poster);
+                return null;
+            }
+            
+            MapItemManager.give(getPlayer(), map);
+
+        } catch (EconomyNotEnabledException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (InsufficientFundsException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
         return null;
+        
     }
 
     @Override

--- a/src/main/java/fr/moribus/imageonmap/map/ImageMap.java
+++ b/src/main/java/fr/moribus/imageonmap/map/ImageMap.java
@@ -37,6 +37,8 @@
 package fr.moribus.imageonmap.map;
 
 import fr.moribus.imageonmap.ImageOnMap;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.ui.MapItemManager;
 import fr.zcraft.quartzlib.components.i18n.I;
 import java.io.File;
@@ -168,8 +170,20 @@ public abstract class ImageMap implements ConfigurationSerializable {
 
     //
 
-    public boolean give(Player player) {
-        return MapItemManager.give(player, this);
+    public boolean give(Player player, boolean ignoreCost) {
+        try {
+            return MapItemManager.give(player, this, ignoreCost);
+        } catch (EconomyNotEnabledException | InsufficientFundsException exception) {
+            if (ignoreCost) {
+                //TODO it shouldn't get to this state
+                exception.printStackTrace();
+            }
+            return false;
+        }
+    }
+
+    public boolean give(Player player) throws EconomyNotEnabledException, InsufficientFundsException {
+        return give(player, false);
     }
 
     protected abstract void postSerialize(Map<String, Object> map);

--- a/src/main/java/fr/moribus/imageonmap/map/MapManager.java
+++ b/src/main/java/fr/moribus/imageonmap/map/MapManager.java
@@ -38,6 +38,8 @@ package fr.moribus.imageonmap.map;
 
 import fr.moribus.imageonmap.ImageOnMap;
 import fr.moribus.imageonmap.PluginConfiguration;
+import fr.moribus.imageonmap.economy.EconomyNotEnabledException;
+import fr.moribus.imageonmap.economy.InsufficientFundsException;
 import fr.moribus.imageonmap.image.ImageIOExecutor;
 import fr.moribus.imageonmap.image.PosterImage;
 import fr.moribus.imageonmap.map.MapManagerException.Reason;
@@ -100,13 +102,15 @@ public abstract class MapManager {
         return false;
     }
 
-    public static ImageMap createMap(UUID playerUUID, int mapID) throws MapManagerException {
+    public static ImageMap createMap(UUID playerUUID, int mapID) 
+            throws MapManagerException, EconomyNotEnabledException, InsufficientFundsException {
         ImageMap newMap = new SingleMap(playerUUID, mapID);
         addMap(newMap);
         return newMap;
     }
 
-    public static ImageMap createMap(PosterImage image, UUID playerUUID, int[] mapsIDs) throws MapManagerException {
+    public static ImageMap createMap(PosterImage image, UUID playerUUID, int[] mapsIDs) 
+            throws MapManagerException, EconomyNotEnabledException, InsufficientFundsException {
         ImageMap newMap;
 
         if (image.getImagesCount() == 1) {
@@ -141,7 +145,8 @@ public abstract class MapManager {
         return ((MapMeta) meta).hasMapId() ? ((MapMeta) meta).getMapId() : 0;
     }
 
-    public static void addMap(ImageMap map) throws MapManagerException {
+    public static void addMap(ImageMap map) 
+            throws MapManagerException, EconomyNotEnabledException, InsufficientFundsException {
         getPlayerMapStore(map.getUserUUID()).addMap(map);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,3 +40,25 @@ save-full-image: false
 #  - cdn.discordapp.com
 images-hostnames-whitelist:
 
+#-------------------------------------------------------------------------------
+# Economy
+
+# Enables Vault-compatible economy plugin (requires Vault and a Vault
+# compatible economy plugin to work) if set to true
+enable-economy: false
+
+# Should the cost to create a splatter map scale with the size of the image?
+# i.e. cost-per-map * width * height
+# If set to false then the cost to create a splatter map is just the
+# cost-per-map no matter what the dimensions of the splatter map are.
+scale-map-cost: true
+
+cost-per-map: 100
+
+# Should the cost to copy a splatter map scale with the size of the image?
+# This is equivalent to scale-map-cost but is applied whenever the player
+# wishes to get a copy of a pre-existing map.
+scale-copy-cost: false
+
+# The cost for each copy of the 
+cost-per-copy: 50

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: fr.moribus.imageonmap.ImageOnMap
 version: "4.2.2"
 api-version: "1.13"
 
+softdepend: [Vault]
 
 commands:
   tomap:
@@ -42,6 +43,8 @@ permissions:
       imageonmap.bypassimagelimit: false
       imageonmap.bypasswhitelist: true
       imageonmap.placeinvisiblesplattermap: true
+      imageonmap.ignoremapcost: true
+      imageonmap.ignorecopycost: true
 
   imageonmap.userender:
     description: "Allows you to use /tomap and related commands (/maptool getremaining). Alias of imageonmap.new."
@@ -130,3 +133,11 @@ permissions:
   imageonmap.placeinvisiblesplattermap:
     description: "Allows you to make the item frame on which you placed your splatter map invisible."
     default: true
+
+  imageonmap.ignoremapcost:
+    description: "Makes making maps free (if economy is enabled)"
+    default: op
+
+  imageonmap.ignorecopycost:
+    description: "Makes making copies of splatter maps free (if economy is enabled)"
+    default: op


### PR DESCRIPTION
I created a `EconomyComponent` that extends a `QuartzComponent` but I'm
unfortunately not fully across the `QuartzLib` pattern so I will probably
need some guidance there.

The base functionality should be included to withdraw money from
player's accounts if they enable economy in the config and set costs.

What I would like to include next is notifications to the player so they
know how much has been removed or if an error occurred. I would also like
to include a confirm/deny option which tells the player how much the
operation is going to cost them before they do it.

I'm uncertain of the best way to go about telling the player how much
a copy of a poster is going to cost before they take it.

Also, I know you are a predominantly French team, so I am sorry that I
only know English. Any assistance is greatly appreciated :)