### PR TITLE
Make dupe bug less harmful to servers, barrier block, and emerald change to redstone powder and green dye respectively.

### DIFF
--- a/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
+++ b/src/main/java/fr/moribus/imageonmap/gui/MapDetailGui.java
@@ -173,7 +173,7 @@ public class MapDetailGui extends ExplorerGui<Integer> {
         }
 
         if (canDelete) {
-            action("delete", deleteSlot, new ItemStackBuilder(Material.BARRIER)
+            action("delete", deleteSlot, new ItemStackBuilder(Material.REDSTONE)
                     .title(I.t(getPlayerLocale(), "{red}Delete this image"))
                     .longLore(I.t(getPlayerLocale(),
                             "{gray}Deletes this map {white}forever{gray}. This action cannot be undone!"))
@@ -194,7 +194,7 @@ public class MapDetailGui extends ExplorerGui<Integer> {
             backSlot++;
         }
 
-        action("back", backSlot, new ItemStackBuilder(Material.EMERALD)
+        action("back", backSlot, new ItemStackBuilder(Material.GREEN_DYE)
                 .title(I.t(getPlayerLocale(), "{green}« Back"))
                 .lore(I.t(getPlayerLocale(), "{gray}Go back to the list."))
         );


### PR DESCRIPTION
Change barrier block to redstone powder, and emerald to green dye temp fix for double click dupe bug in details and options GUI for a specific map. Redstone powder and green dye is safer than barrier blocks and emeralds.